### PR TITLE
Role for stores that can estimate cardinality

### DIFF
--- a/lib/Attean/API/Store.pm
+++ b/lib/Attean/API/Store.pm
@@ -83,6 +83,13 @@ package Attean::API::TimeCacheableTripleStore 0.001 {
 	requires 'metime_for_triples';
 }
 
+package Attean::API::CountEstimatableTripleStore 0.001 {
+	use Moo::Role;
+	with 'Attean::API::TripleStore';
+	
+	requires 'estimated_count_triples';
+}
+
 package Attean::API::QuadStore 0.001 {
 	use Moo::Role;
 	with 'Attean::API::Store';
@@ -150,6 +157,13 @@ package Attean::API::TimeCacheableQuadStore 0.001 {
 	with 'Attean::API::QuadStore';
 	
 	requires 'mtime_for_quads';
+}
+
+package Attean::API::CountEstimatableQuadStore 0.001 {
+	use Moo::Role;
+	with 'Attean::API::QuadStore';
+	
+	requires 'estimated_count_quads';
 }
 
 1;


### PR DESCRIPTION
Hi!

How about this? I'm sure there are stores that can provide a quick estimate of cardinality, that seems important for many tasks. HDT can do that, actually.

I'm not sure it is a good idea, though, perhaps it is better to bake into the TripleStore and QuadStore roles, where they have a default implementation that is simply an alias for count_*.

Cheers,

Kjetil