### PR TITLE
Quad-pattern only HSP heuristics

### DIFF
--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -742,6 +742,18 @@ __END__
 Please report any bugs or feature requests to through the GitHub web interface
 at L<https://github.com/kasei/attean/issues>.
 
+=head1 REFERENCES
+
+The seminal reference for Iterative Dynamic Programming is "Iterative
+dynamic programming: a new class of query optimization algorithms" by
+D. Kossmann and K. Stocker, ACM Transactions on Database Systems
+(2000).
+
+The heuristics to order triple patterns in this module is
+influenced by L<The ICS-FORTH Heuristics-based SPARQL Planner
+(HSP)|http://www.ics.forth.gr/isl/index_main.php?l=e&c=645>.
+
+
 =head1 SEE ALSO
 
 L<http://www.perlrdf.org/>

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -685,7 +685,7 @@ sub-plan participating in the join.
 # spo: 8
 # sao: 10
 # s?l: 14
-# s?p: 16
+# s?o: 16
 # ?pl: 25
 # ?po: 27
 # ?ao: 29

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -598,7 +598,8 @@ sub-plan participating in the join.
 			my @children	= @{ $plan->children };
 			if ($plan->isa('Attean::Plan::Quad')) {
 				my @vars	= map { $_->value } grep { blessed($_) and $_->does('Attean::API::Variable') } $plan->values;
-				return 3 * scalar(@vars);
+				# This gives a cost increasing at a reasonable pace
+				return $self->_hsp_heuristic_triple_sum($plan) * scalar(@vars);
 			} elsif ($plan->isa('Attean::Plan::NestedLoopJoin')) {
 				my $jv			= $plan->join_variables;
 				my $mult		= scalar(@$jv) ? 1 : 5;	# penalize cartesian joins


### PR DESCRIPTION
Here's the code for Heuristic 1 and 4, which only applies to individual quad patterns.

What it does, is to replace the fixed factor 3 that you used to multiply the number of variables in the quad pattern, with a function that depends on the position of the variables in the triple pattern. The heuristic doesn't say anything about the graph, but that doesn't change that much.

Since we don't know anything about the actual selectivity, I suppose this is simply a reasonable guess. If we look at the different triple patterns, these are the sums it computes, and the final cost estimate:

Pattern  | Sum | Cost
----------|-----|-----
spl | 6 | 0
spo | 8 | 0 
sao | 10 | 0
s?l | 14 | 14
s?o | 16 | 16
?pl | 25 | 25
?po | 27 | 27 
?ao | 29 | 29
sp? | 30 | 30
sa? | 32 | 32
??l | 33 | 66
??o | 35 | 70
s?? | 38 | 76
?p? | 49 | 98
?a? | 51 | 102
??? | 57 | 171

Since there are nothing elsewhere that uses fixed numbers in the cost estimate, I suppose getting the cost in the [0,12] intervall that you had before is not needed, but this progression of weights seem reaonable to me, so dividing by a fixed factor could fix that.