### PR TITLE
HSP Heuristic 2 attempt

### DIFF
--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -602,7 +602,46 @@ sub-plan participating in the join.
 				return $self->_hsp_heuristic_triple_sum($plan) * scalar(@vars);
 			} elsif ($plan->isa('Attean::Plan::NestedLoopJoin')) {
 				my $jv			= $plan->join_variables;
-				my $mult		= scalar(@$jv) ? 1 : 5;	# penalize cartesian joins
+				my $mult		   = 1;
+				if (scalar(@$jv)) {
+					if ( all { $_->isa('Attean::Plan::Quad') } @children[0..1]) {
+						my $var = ${$jv}[0]; # We will join on this
+						my @lnodes = $children[0]->values;
+						my @rnodes = $children[1]->values;
+						# Now, find where the join variables are in the triple patterns
+						my %joinpos;
+						for (my $i = 0; $i <= 2; $i++) {
+							if ($lnodes[$i]->does('Attean::API::Variable') && $lnodes[$i]->value eq $var) {
+								$joinpos{l} = $i;
+							}
+							if ($rnodes[$i]->does('Attean::API::Variable') && $rnodes[$i]->value eq $var) {
+								$joinpos{r} = $i;
+							}
+							last if scalar keys(%joinpos) >= 2; # Perhaps a bit premature optimization
+						}
+						my $joinpos = join("", sort values(%joinpos)); # We can now match on this string
+						if ($joinpos eq '12') { # The penalization numbers come mostly out from thin air
+							$mult = 1.1;
+						}
+						elsif ($joinpos eq '01') {
+							$mult = 1.2;
+						}
+						elsif ($joinpos eq '02') {
+							$mult = 1.5;
+						}
+						elsif ($joinpos eq '22') {
+							$mult = 1.6;
+						}
+						elsif ($joinpos eq '00') {
+							$mult = 1.8;
+						}
+						elsif ($joinpos eq '11') {
+							$mult = 2;
+						}
+					}
+				} else {
+					$mult = 5; # penalize cartesian joins
+				}
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
 				if ($lcost == 0) {

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -601,7 +601,6 @@ sub-plan participating in the join.
 				# This gives a cost increasing at a reasonable pace
 				return $self->_hsp_heuristic_triple_sum($plan) * scalar(@vars);
 			} elsif ($plan->isa('Attean::Plan::NestedLoopJoin')) {
-				my $mult = $self->_penalize_joins($plan);
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
 				if ($lcost == 0) {
@@ -609,11 +608,10 @@ sub-plan participating in the join.
 				} elsif ($rcost == 0) {
 					$cost	= $lcost;
 				} else {
+					my $mult = $self->_penalize_joins($plan);
 					$cost	= $mult * $lcost * $rcost;
 				}
 			} elsif ($plan->isa('Attean::Plan::HashJoin')) {
-				my $jv			= $plan->join_variables;
-				my $mult		= scalar(@$jv) ? 1 : 5;	# penalize cartesian joins
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
 				if ($lcost == 0) {
@@ -621,6 +619,7 @@ sub-plan participating in the join.
 				} elsif ($rcost == 0) {
 					$cost	= $lcost;
 				} else {
+					my $mult = $self->_penalize_joins($plan);
 					$cost	= $mult * ($lcost + $rcost);
 				}
 			} elsif ($plan->isa('Attean::Plan::Unique')) {

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -751,24 +751,16 @@ sub-plan participating in the join.
 					last if scalar keys(%joinpos) >= 2; # Perhaps a bit premature optimization
 				}
 				my $joinpos = join("", sort values(%joinpos)); # We can now match on this string
-				if ($joinpos eq '12') { # The penalization numbers come mostly out from thin air
-					$mult = 1.1;
+				my %costs = ('12' => 1.1, # The penalty numbers come mostly out from thin air
+								 '01' => 1.2,
+								 '02' => 1.5,
+								 '22' => 1.6,
+								 '00' => 1.8,
+								 '11' => 2);
+				if (exists $costs{$joinpos}) {
+					$mult = $costs{$joinpos};
 				}
-				elsif ($joinpos eq '01') {
-					$mult = 1.2;
-				}
-				elsif ($joinpos eq '02') {
-					$mult = 1.5;
-				}
-				elsif ($joinpos eq '22') {
-					$mult = 1.6;
-				}
-				elsif ($joinpos eq '00') {
-					$mult = 1.8;
-				}
-				elsif ($joinpos eq '11') {
-					$mult = 2;
-				}
+				#warn "Penalty: $mult for quads:\n" . $children[0]->as_string . $children[1]->as_string
 			}
 		} else {
 			$mult = 5; # penalize cartesian joins


### PR DESCRIPTION
Hi!

I figured I'll just hack what I had in mind for HSP Heuristic 2. I'm not doing the tree traversal, just checking if it joins two quads. Then, it finds the position of the first join variable, then assign a penalty to $mult based on the HSP Heuristic 2. Very rough, but this would penalize different join types, right? 
So, it might well be in the default implementation?

Let me know if it is still rather misunderstood! :-)

Kjetil