### PR TITLE
Disable stable sort in prune

### DIFF
--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -475,7 +475,7 @@ sub-plan participating in the join.
 		my $model		= shift;
 		my $interesting	= shift;
 		my @plans		= @{ shift || [] };
-		
+	        no  sort 'stable';
 		my @sorted	= map { $_->[1] } sort { $a->[0] <=> $b->[0] } map { [$self->cost_for_plan($_, $model), $_] } @plans;
 		return splice(@sorted, 0, 5);
 	}


### PR DESCRIPTION
OK, I took the conservative approach, and disabled stable sort in prune, since that is called often, will certainly not require stability, and may be a somewhat long list.

Kjetil