### PR TITLE
Small POD cleanups

### DIFF
--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -50,6 +50,7 @@ package Attean::IDPQueryPlanner 0.006 {
 
 	with 'Attean::API::CostPlanner';
 	has 'counter' => (is => 'rw', isa => Int, default => 0);
+
 =back
 
 =head1 METHODS
@@ -65,7 +66,7 @@ package Attean::IDPQueryPlanner 0.006 {
 		$self->counter($c+1);
 		return sprintf('.%s-%d', $type, $c);
 	}
-	
+
 =item C<< plans_for_algebra( $algebra, $model, \@active_graphs, \@default_graphs ) >>
 
 Returns L<Attean::API::Plan> objects representing alternate query plans for
@@ -333,7 +334,7 @@ the supplied C<< $active_graph >>.
 		
 		return Attean::Plan::Project->new(children => [$plan], variables => \@pvars, distinct => $distinct, in_scope_variables => \@vars, ordered => \@porder);
 	}
-	
+
 =item C<< bgp_join_plans( $bgp, $model, \@active_graphs, \@default_graphs, \@interesting_order, \@plansA, \@plansB, ... ) >>
 
 Returns a list of alternative plans for the join of a set of triples.
@@ -392,7 +393,7 @@ triple participating in the join.
 			return $plan;
 		}
 	}
-	
+
 =item C<< group_join_plans( $model, \@active_graphs, \@default_graphs, \@interesting_order, \@plansA, \@plansB, ... ) >>
 
 Returns a list of alternative plans for the join of a set of sub-plans.

--- a/lib/Attean/Result.pm
+++ b/lib/Attean/Result.pm
@@ -44,19 +44,20 @@ Returns the HASH reference containing the variable bindings for this result.
 =cut
 
 	has 'bindings' => (is => 'ro', isa => HashRef[ConsumerOf['Attean::API::Term']], default => sub { +{} });
-	
+
 =item C<< value( $name ) >>
 
 Returns the term object bound to the C<< $name >>d variable, or undef if the
 name does not map to a term.
 
 =cut
+
 	sub value {
 		my $self	= shift;
 		my $k		= shift;
 		return $self->bindings->{$k};
 	}
-	
+
 =item C<< variables >>
 
 Returns a list of the variable names that are bound to terms in this result
@@ -68,7 +69,7 @@ object.
 		my $self	= shift;
 		return keys %{ $self->bindings };
 	}
-	
+
 =item C<< as_string >>
 
 Returns a string serialization of the variable bindings contained in the result.

--- a/lib/Attean/TermMap.pm
+++ b/lib/Attean/TermMap.pm
@@ -49,7 +49,7 @@ package Attean::TermMap 0.006 {
 		}
 		return $class->$orig(@_);
 	};
-	
+
 =item C<< canonicalization_map >>
 
 Returns a new L<Attean::TermMap> that canonicalizes recognized typed
@@ -71,7 +71,7 @@ L<Attean::API::Literal> values.
 			return $term;
 		});
 	}
-	
+
 =item C<< uuid_blank_map >>
 
 Returns a new L<Attean::TermMap> that renames blank nodes with UUID values.
@@ -93,7 +93,7 @@ Returns a new L<Attean::TermMap> that renames blank nodes with UUID values.
 			return $new;
 		});
 	}
-	
+
 =item C<< short_blank_map >>
 
 Returns a new L<Attean::TermMap> that renames blank nodes with short
@@ -134,7 +134,7 @@ alphabetic names (e.g. _:a, _:b).
 =head1 METHODS
 
 =over 4
-	
+
 =item C<< map( $term ) >>
 
 Returns the term that is mapped to by the supplied C<< $term >>.
@@ -146,7 +146,7 @@ Returns the term that is mapped to by the supplied C<< $term >>.
 		my $term	= shift;
 		return $self->mapper->( $term );
 	}
-	
+
 =item C<< binding_mapper >>
 
 Returns a mapping function reference that maps L<Attean::API::Binding>


### PR DESCRIPTION
Hi!

Emacs refused to highlight because of some whitespace, and podchecker complained a bit too.

Kjetil