### PR TITLE
Trace logging in prune_plans

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ requires		'Scalar::Util'				=> 0;
 requires		'Set::Scalar'				=> 0;
 requires		'Type::Tiny'				=> 0;
 requires		'Moo'						=> 1.006000;
+requires		'MooX::Log::Any'			=> 0;
 requires		'Sub::Util'					=> 1.40;
 requires		'Sub::Install'				=> 0;
 requires		'Set::Scalar'				=> 0;

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -49,7 +49,8 @@ package Attean::IDPQueryPlanner 0.009 {
 	use Math::Cartesian::Product;
 	use namespace::clean;
 
-	with 'Attean::API::CostPlanner';
+	with 'Attean::API::CostPlanner',
+	     'MooX::Log::Any';
 	has 'counter' => (is => 'rw', isa => Int, default => 0);
 
 =back
@@ -713,6 +714,12 @@ sub-plan participating in the join.
 		my @plans		= @{ shift || [] };
 		no  sort 'stable';
 		my @sorted	= map { $_->[1] } sort { $a->[0] <=> $b->[0] } map { [$self->cost_for_plan($_, $model), $_] } @plans;
+		if ($self->log->is_trace) {
+			$self->log->trace('============= Plan iteration separator ==============');
+			foreach my $plan (@sorted){
+				$self->log->trace("Cost: " . $self->cost_for_plan($plan, $model) . " for plan:\n". $plan->as_string);
+			}
+		}
 		return splice(@sorted, 0, 5);
 	}
 	


### PR DESCRIPTION
Just a start of what we discussed in #19. I added the trace logging to prune_plans, to help debug my invalid plans problem. 

Would also be interesting to hear if this is at all a good idea.

Kjetil