### PR TITLE
as_sparql test that dies with a blank

### DIFF
--- a/t/serializer-sparql.t
+++ b/t/serializer-sparql.t
@@ -561,6 +561,23 @@ subtest 'expected tokens: aggregation' => sub {
 # Attean::Algebra::Extend
 # Attean::Algebra::Sequence
 
+{
+	note('BGP with blank');
+	my $b		= blank('person');
+	my $rdf_type	= iri('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+	my $foaf_name	= iri('http://xmlns.com/foaf/0.1/name');
+	my $foaf_knows	= iri('http://xmlns.com/foaf/0.1/knows');
+	my $foaf_Person	= iri('http://xmlns.com/foaf/0.1/Person');
+	my $bgp1	= Attean::Algebra::BGP->new( triples => [
+		triplepattern($b, $rdf_type, $foaf_Person),
+		triplepattern($b, $foaf_name, variable('name')),
+		triplepattern($b, $foaf_knows, variable('knows')),
+	] );
+	lives_ok {
+		my $string = $bgp1->as_sparql;
+	} 'as_sparql returns a string on blank';
+}
+
 done_testing();
 exit;
 


### PR DESCRIPTION
I found a problem calling as_sparql on BGPs that have a blank node. Created a test that dies in this case which is in this PR.

This is the stack trace from my code:
```
Died at /home/kjetil/dev/attean/lib/Attean/API/Term.pm line 492.
        Attean::API::Blank::sparql_tokens('Attean::Blank=HASH(0x49eec20)') called at /home/kjetil/dev/attean/lib/Attean/API/Binding.pm line 164
        Attean::API::TripleOrQuadPattern::sparql_tokens('Attean::Triple=HASH(0xa6c9220)') called at /home/kjetil/dev/attean/lib/Attean/Algebra.pm line 518
        Attean::Algebra::BGP::sparql_tokens('Attean::Algebra::BGP=HASH(0xa8aecc0)') called at /home/kjetil/dev/attean/lib/Attean/API/Query.pm line 153
        Attean::API::SPARQLSerializable::as_sparql('Attean::Algebra::BGP=HASH(0xa8aecc0)') called at t/simple-sparql-planner.t line 246
        main::__ANON__() called at /usr/share/perl/5.18/Test/Builder.pm line 234
        Test::Builder::__ANON__() called at /usr/share/perl/5.18/Test/Builder.pm line 239
        eval {...} called at /usr/share/perl/5.18/Test/Builder.pm line 239
        Test::Builder::subtest('Test::Builder=HASH(0x280cfa0)', '5-triple BGP with join variable with cache two cached', 'CODE(0xa6c9568)') called at /usr/share/perl/5.18/Test/More.pm line 747
        Test::More::subtest('5-triple BGP with join variable with cache two cached', 'CODE(0xa6c9568)') called at /usr/share/perl/5.18/Test/Builder.pm line 252.
        Test::Builder::subtest('Test::Builder=HASH(0x280cfa0)', '5-triple BGP with join variable with cache two cached', 'CODE(0xa6c9568)') called at /usr/share/perl/5.18/Test/More.pm line 747
        Test::More::subtest('5-triple BGP with join variable with cache two cached', 'CODE(0xa6c9568)') called at t/simple-sparql-planner.t line 263
```
I hope it is easy to track down with the test.

Cheers,

Kjetil
