### PR TITLE
Simplify a bit in the costs

### DIFF
--- a/lib/Attean/API/QueryPlanner.pm
+++ b/lib/Attean/API/QueryPlanner.pm
@@ -168,14 +168,7 @@ package Attean::API::SimpleCostPlanner 0.011 {
 				my $joined		= $plan->children_are_variable_connected;
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
-				if ($lcost == 0) {
-					$cost	= $rcost;
-				} elsif ($rcost == 0) {
-					$cost	= $lcost;
-				} else {
-					$cost	= ($lcost + $rcost);
-				}
-
+				$cost	= ($lcost + $rcost);
 				$cost	*= 100 unless ($plan->children_are_variable_connected);
 			} elsif ($plan->isa('Attean::Plan::Service')) {
 				my $scost	= 10;


### PR DESCRIPTION
Here's a small simplification. 

I also tried to simplify the above if, not identical semantics, but possibly good enough if it helped. Tried to make the following benchmark script, but the results didn't make much sense, so I don't know... 

```perl
#!/usr/bin/perl

use strict;
use warnings;

use Benchmark qw(:all) ;


sub current {
	my $in = shift;
	my $lcost		= cost_for_plan($in);
	my $rcost		= cost_for_plan($in);
	my $cost;
	if ($lcost == 0) {
		$cost	= $rcost;
	} elsif ($rcost == 0) {
		$cost	= $lcost;
	} else {
		$cost	= $lcost * $rcost;
	}
	return $cost;
}

sub trythis {
	my $in = shift;
	my $lcost		= cost_for_plan($in) || 1;
	my $rcost		= cost_for_plan($in) || 1;
	return $lcost * $rcost;
}

sub cost_for_plan {
	return shift;
}


timethese(100000000000, {
					 'current0' => &current(0),
					 'trythis0' => &trythis(0),
					 'current1000' => &current(1000),
					 'trythis1000' => &trythis(1000)
					});
```
It still complained about too few iterations in spite of having 100000000000 of them and taking 15 hours...

So, probably not worth it. But the patch can't possibly do anything wrong. :-)