### PR TITLE
Croak if the triple or quad constructor gets a variable

### DIFF
--- a/lib/Attean/API/Binding.pm
+++ b/lib/Attean/API/Binding.pm
@@ -264,7 +264,16 @@ package Attean::API::TripleOrQuadPattern 0.011 {
 
 package Attean::API::TripleOrQuad 0.011 {
 	use Moo::Role;
+	use List::MoreUtils qw(any);
+	use Carp;
 	with 'Attean::API::TripleOrQuadPattern';
+
+	sub BUILD {
+		my $self = shift;
+		if (any { $_->does('Attean::API::Variable') } $self->values) {
+			croak 'Use a Pattern class to construct when using variables';
+		}
+	}
 }
 
 package Attean::API::TriplePattern 0.011 {

--- a/t/algebra.t
+++ b/t/algebra.t
@@ -55,7 +55,7 @@ if ($ENV{ATTEAN_TYPECHECK}) {
 }
 
 {
-	my $t	= triple(variable('s'), iri('p'), literal('1'));
+	my $t	= triplepattern(variable('s'), iri('p'), literal('1'));
 	my $bgp	= Attean::Algebra::BGP->new(triples => [$t]);
 	my $join	= Attean::Algebra::Join->new( children => [$bgp, $bgp] );
 	my @walk;
@@ -159,7 +159,7 @@ subtest 'Quad canonicalization' => sub {
 };
 
 {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my @groups	= Attean::ValueExpression->new( value => variable('s') );
 	my @aggs	= Attean::AggregateExpression->new(
@@ -180,7 +180,7 @@ subtest 'Quad canonicalization' => sub {
 
 {
 	note('Aggregation');
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my @groups	= Attean::ValueExpression->new( value => variable('s') );
 	my @aggs	= Attean::AggregateExpression->new(
@@ -203,9 +203,9 @@ subtest 'Quad canonicalization' => sub {
 	note('Ranking');
 	# RANKing example for 2 youngest students per school
 	my $bgp		= Attean::Algebra::BGP->new(triples => [
-		triple(variable('p'), iri('ex:name'), variable('name')),
-		triple(variable('p'), iri('ex:school'), variable('school')),
-		triple(variable('p'), iri('ex:age'), variable('age')),
+		triplepattern(variable('p'), iri('ex:name'), variable('name')),
+		triplepattern(variable('p'), iri('ex:school'), variable('school')),
+		triplepattern(variable('p'), iri('ex:age'), variable('age')),
 	]);
 	my @groups	= Attean::ValueExpression->new( value => variable('school') );
 	my $r_agg	= Attean::AggregateExpression->new(

--- a/t/cost_planner.t
+++ b/t/cost_planner.t
@@ -23,10 +23,10 @@ does_ok($p, 'Attean::API::QueryPlanner');
 my $store	= AtteanX::Store::Memory->new();
 my $model	= Attean::MutableQuadModel->new( store => $store );
 my $graph	= iri('http://example.org/');
-my $t		= triple(variable('s'), iri('p'), literal('1'));
-my $u		= triple(variable('s'), iri('p'), variable('o'));
-my $v		= triple(variable('s'), iri('q'), blank('xyz'));
-my $w		= triple(variable('a'), iri('b'), iri('c'));
+my $t		= triplepattern(variable('s'), iri('p'), literal('1'));
+my $u		= triplepattern(variable('s'), iri('p'), variable('o'));
+my $v		= triplepattern(variable('s'), iri('q'), blank('xyz'));
+my $w		= triplepattern(variable('a'), iri('b'), iri('c'));
 
 subtest 'Empty BGP' => sub {
 	note("An empty BGP should produce the join identity table plan");
@@ -172,9 +172,9 @@ subtest 'Variable named graph (model with 0 named graphs)' => sub {
 };
 
 subtest 'Naive join planning should leave cartesian products intact' => sub {
-	my $t1		= triple(variable('s'), iri('p'), literal('1'));	# ?s
-	my $t2		= triple(variable('a'), iri('b'), variable('o'));	# ?a ?o
-	my $t3		= triple(variable('s'), iri('p'), variable('o'));	# ?s ?o
+	my $t1		= triplepattern(variable('s'), iri('p'), literal('1'));	# ?s
+	my $t2		= triplepattern(variable('a'), iri('b'), variable('o'));	# ?a ?o
+	my $t3		= triplepattern(variable('s'), iri('p'), variable('o'));	# ?s ?o
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t1, $t2, $t3]);
 	my $plan	= $p->plan_for_algebra($bgp, $model, [$graph]);
 	does_ok($plan, 'Attean::API::Plan::Join');

--- a/t/idp_planner.t
+++ b/t/idp_planner.t
@@ -51,10 +51,10 @@ does_ok($p, 'Attean::API::CostPlanner');
 	my $store	= TestStore->new();
 	my $model	= Attean::MutableQuadModel->new( store => $store );
 	my $graph	= iri('http://example.org/');
-	my $t		= triple(variable('s'), iri('p'), literal('1'));
-	my $u		= triple(variable('s'), iri('p'), variable('o'));
-	my $v		= triple(variable('s'), iri('q'), blank('xyz'));
-	my $w		= triple(variable('a'), iri('b'), iri('c'));
+	my $t		= triplepattern(variable('s'), iri('p'), literal('1'));
+	my $u		= triplepattern(variable('s'), iri('p'), variable('o'));
+	my $v		= triplepattern(variable('s'), iri('q'), blank('xyz'));
+	my $w		= triplepattern(variable('a'), iri('b'), iri('c'));
 
 	subtest 'Empty BGP' => sub {
 		note("An empty BGP should produce the join identity table plan");

--- a/t/join_rotating_planner.t
+++ b/t/join_rotating_planner.t
@@ -87,10 +87,10 @@ package MyTestStore {
 	my $store	= MyTestStore->new();
 	my $model	= Attean::MutableQuadModel->new( store => $store );
 	my $graph	= iri('http://example.org/');
-# 	my $t		= triple(variable('s'), iri('p'), literal('1'));
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
-	my $v		= triple(variable('s'), iri('q'), literal('xyz'));
-	my $w		= triple(variable('o'), iri('b'), iri('c'));
+# 	my $t		= triplepattern(variable('s'), iri('p'), literal('1'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
+	my $v		= triplepattern(variable('s'), iri('q'), literal('xyz'));
+	my $w		= triplepattern(variable('o'), iri('b'), iri('c'));
 
 	my $bgp1	= Attean::Algebra::BGP->new(triples => [$t]);
 	my $bgp2	= Attean::Algebra::BGP->new(triples => [$w]);

--- a/t/naive_planner.t
+++ b/t/naive_planner.t
@@ -22,10 +22,10 @@ does_ok($p, 'Attean::API::QueryPlanner');
 my $store	= AtteanX::Store::Memory->new();
 my $model	= Attean::MutableQuadModel->new( store => $store );
 my $graph	= iri('http://example.org/');
-my $t		= triple(variable('s'), iri('p'), literal('1'));
-my $u		= triple(variable('s'), iri('p'), variable('o'));
-my $v		= triple(variable('s'), iri('q'), blank('xyz'));
-my $w		= triple(variable('a'), iri('b'), iri('c'));
+my $t		= triplepattern(variable('s'), iri('p'), literal('1'));
+my $u		= triplepattern(variable('s'), iri('p'), variable('o'));
+my $v		= triplepattern(variable('s'), iri('q'), blank('xyz'));
+my $w		= triplepattern(variable('a'), iri('b'), iri('c'));
 
 subtest 'Empty BGP' => sub {
 	note("An empty BGP should produce the join identity table plan");
@@ -171,9 +171,9 @@ subtest 'Variable named graph (model with 0 named graphs)' => sub {
 };
 
 subtest 'Naive join planning should leave cartesian products intact' => sub {
-	my $t1		= triple(variable('s'), iri('p'), literal('1'));	# ?s
-	my $t2		= triple(variable('a'), iri('b'), variable('o'));	# ?a ?o
-	my $t3		= triple(variable('s'), iri('p'), variable('o'));	# ?s ?o
+	my $t1		= triplepattern(variable('s'), iri('p'), literal('1'));	# ?s
+	my $t2		= triplepattern(variable('a'), iri('b'), variable('o'));	# ?a ?o
+	my $t3		= triplepattern(variable('s'), iri('p'), variable('o'));	# ?s ?o
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t1, $t2, $t3]);
 	my $plan	= $p->plan_for_algebra($bgp, $model, [$graph]);
 	does_ok($plan, 'Attean::API::Plan::Join');

--- a/t/plan.t
+++ b/t/plan.t
@@ -21,11 +21,11 @@ my $store	= AtteanX::Store::Memory->new();
 my $model	= Attean::MutableQuadModel->new( store => $store );
 
 my $graph	= iri('http://example.org/');
-my $t		= triple(variable('s'), iri('p'), literal('1'));
-my $u		= triple(variable('s'), iri('p'), variable('o'));
-my $v		= triple(variable('s'), iri('q'), blank('xyz'));
-my $w		= triple(variable('a'), iri('b'), iri('c'));
-my $x		= triple(variable('a'), variable('b'), iri('c'));
+my $t		= triplepattern(variable('s'), iri('p'), literal('1'));
+my $u		= triplepattern(variable('s'), iri('p'), variable('o'));
+my $v		= triplepattern(variable('s'), iri('q'), blank('xyz'));
+my $w		= triplepattern(variable('a'), iri('b'), iri('c'));
+my $x		= triplepattern(variable('a'), variable('b'), iri('c'));
 
 sub test_triples_for_connected_plan {
 	my $triples		= shift;

--- a/t/serializer-sparql.t
+++ b/t/serializer-sparql.t
@@ -50,7 +50,7 @@ subtest 'expected tokens: 1-triple BGP tokens' => sub {
 };
 
 subtest 'expected tokens: 2-BGP join tokens' => sub {
-	my $t	= triple(variable('s'), iri('p'), literal('1'));
+	my $t	= triplepattern(variable('s'), iri('p'), literal('1'));
 	my $bgp	= Attean::Algebra::BGP->new(triples => [$t]);
 	my $a	= Attean::Algebra::Join->new( children => [$bgp, $bgp] );
 	my $i	= $a->sparql_tokens;
@@ -62,8 +62,8 @@ subtest 'expected tokens: 2-BGP join tokens' => sub {
 };
 
 subtest 'expected tokens: 2-triple BGP tokens with language and datatype' => sub {
-	my $t	= triple(variable('s'), iri('p'), Attean::Literal->new(value => '1', datatype => iri('http://example.org/type')));
-	my $u	= triple(variable('s'), iri('q'), Attean::Literal->new(value => 'hello', language => 'en-US'));
+	my $t	= triplepattern(variable('s'), iri('p'), Attean::Literal->new(value => '1', datatype => iri('http://example.org/type')));
+	my $u	= triplepattern(variable('s'), iri('q'), Attean::Literal->new(value => 'hello', language => 'en-US'));
 	
 	my $bgp	= Attean::Algebra::BGP->new(triples => [$t, $u]);
 	my $a	= Attean::Algebra::Join->new( children => [$bgp] );
@@ -349,8 +349,8 @@ subtest 'expected tokens: union tokens' => sub {
 };
 
 subtest 'expected tokens: minus tokens' => sub {
-	my $lhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
-	my $rhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('2'))]);
+	my $lhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
+	my $rhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('2'))]);
 	my $a	= Attean::Algebra::Minus->new( children => [$lhs, $rhs] );
 	my $i	= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -360,8 +360,8 @@ subtest 'expected tokens: minus tokens' => sub {
 };
 
 subtest 'expected tokens: optional tokens' => sub {
-	my $lhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
-	my $rhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('2'))]);
+	my $lhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
+	my $rhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('2'))]);
 	my $a	= Attean::Algebra::LeftJoin->new( children => [$lhs, $rhs] );
 	my $i	= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -384,8 +384,8 @@ subtest 'expected tokens: table tokens' => sub {
 };
 
 subtest 'expected tokens: optional+filter tokens' => sub {
-	my $lhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
-	my $rhs	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('2'))]);
+	my $lhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
+	my $rhs	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('2'))]);
 	my $e		= Attean::ValueExpression->new( value => variable('s') );
 	my $expr	= Attean::FunctionExpression->new( operator => 'ISIRI', children => [$e] );
 	my $a	= Attean::Algebra::LeftJoin->new( children => [$lhs, $rhs], expression => $expr );
@@ -397,7 +397,7 @@ subtest 'expected tokens: optional+filter tokens' => sub {
 };
 
 subtest 'expected tokens: project' => sub {
-	my $bgp		= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
+	my $bgp		= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
 	my $a		= Attean::Algebra::Project->new( children => [$bgp], variables => [variable('p')] );
 	my $i		= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -408,7 +408,7 @@ subtest 'expected tokens: project' => sub {
 };
 
 subtest 'expected tokens: comparator tokens' => sub {
-	my $bgp		= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
+	my $bgp		= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
 	my $expr	= Attean::ValueExpression->new( value => variable('s') );
 	my $a		= Attean::Algebra::Comparator->new(ascending => 0, expression => $expr);
 	my $i		= $a->sparql_tokens;
@@ -419,7 +419,7 @@ subtest 'expected tokens: comparator tokens' => sub {
 };
 
 subtest 'expected tokens: comparator tokens' => sub {
-	my $bgp		= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
+	my $bgp		= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
 	my $expr	= Attean::ValueExpression->new( value => variable('s') );
 	my $cmp		= Attean::Algebra::Comparator->new(ascending => 0, expression => $expr);
 	my $a		= Attean::Algebra::OrderBy->new( children => [$bgp], comparators => [$cmp] );
@@ -431,7 +431,7 @@ subtest 'expected tokens: comparator tokens' => sub {
 };
 
 subtest 'expected tokens: ASK tokens' => sub {
-	my $bgp		= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
+	my $bgp		= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
 	my $a		= Attean::Algebra::Ask->new( children => [$bgp] );
 	my $i		= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -442,8 +442,8 @@ subtest 'expected tokens: ASK tokens' => sub {
 };
 
 subtest 'expected tokens: CONSTRUCT tokens' => sub {
-	my $bgp	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
-	my $t	= triple(variable('s'), iri('q'), literal('2'));
+	my $bgp	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
+	my $t	= triplepattern(variable('s'), iri('q'), literal('2'));
 	my $a	= Attean::Algebra::Construct->new( children => [$bgp], triples => [$t] );
 	my $i	= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -454,7 +454,7 @@ subtest 'expected tokens: CONSTRUCT tokens' => sub {
 };
 
 subtest 'expected tokens: DESCRIBE tokens' => sub {
-	my $bgp	= Attean::Algebra::BGP->new(triples => [triple(variable('s'), iri('p'), literal('1'))]);
+	my $bgp	= Attean::Algebra::BGP->new(triples => [triplepattern(variable('s'), iri('p'), literal('1'))]);
 	my $a	= Attean::Algebra::Describe->new( children => [$bgp], terms => [variable('s'), iri('q')] );
 	my $i	= $a->sparql_tokens;
 	does_ok($i, 'Attean::API::Iterator');
@@ -465,8 +465,8 @@ subtest 'expected tokens: DESCRIBE tokens' => sub {
 };
 
 subtest 'expected tokens: project expressions tokens' => sub {
-	my $t1		= triple(variable('s'), iri('p'), variable('o1'));
-	my $t2		= triple(variable('s'), iri('q'), variable('o2'));
+	my $t1		= triplepattern(variable('s'), iri('p'), variable('o1'));
+	my $t2		= triplepattern(variable('s'), iri('q'), variable('o2'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t1, $t2]);
 	my $e1		= Attean::ValueExpression->new( value => variable('o1') );
 	my $e2		= Attean::ValueExpression->new( value => variable('o2') );
@@ -491,8 +491,8 @@ subtest 'expected tokens: project expressions tokens' => sub {
 };
 
 subtest 'expected tokens: binary filter tokens' => sub {
-	my $t1		= triple(variable('s'), iri('p'), variable('o1'));
-	my $t2		= triple(variable('s'), iri('q'), variable('o2'));
+	my $t1		= triplepattern(variable('s'), iri('p'), variable('o1'));
+	my $t2		= triplepattern(variable('s'), iri('q'), variable('o2'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t1, $t2]);
 	my $e1		= Attean::ValueExpression->new( value => variable('o1') );
 	my $e2		= Attean::ValueExpression->new( value => variable('o2') );
@@ -505,7 +505,7 @@ subtest 'expected tokens: binary filter tokens' => sub {
 };
 
 subtest 'expected tokens: function filter tokens' => sub {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my $e		= Attean::ValueExpression->new( value => variable('o') );
 	my $expr	= Attean::FunctionExpression->new( operator => 'ISIRI', children => [$e] );
@@ -517,7 +517,7 @@ subtest 'expected tokens: function filter tokens' => sub {
 };
 
 subtest 'expected tokens: cast filter tokens' => sub {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my $e		= Attean::ValueExpression->new( value => variable('o') );
 	my $expr	= Attean::CastExpression->new( datatype => iri('http://www.w3.org/2001/XMLSchema#integer'), children => [$e] );
@@ -529,9 +529,9 @@ subtest 'expected tokens: cast filter tokens' => sub {
 };
 
 subtest 'expected tokens: exists filter tokens' => sub {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
-	my $u		= triple(variable('s'), iri('q'), literal('1'));
+	my $u		= triplepattern(variable('s'), iri('q'), literal('1'));
 	my $expr	= Attean::ExistsExpression->new( pattern => Attean::Algebra::BGP->new(triples => [$u]) );
 	my $a		= Attean::Algebra::Filter->new(children => [$bgp], expression => $expr);
 	my $i		= $a->sparql_tokens;
@@ -541,8 +541,8 @@ subtest 'expected tokens: exists filter tokens' => sub {
 };
 
 subtest 'expected tokens: non-projected extend tokens' => sub {
-	my $t1		= triple(variable('s'), iri('p'), variable('o1'));
-	my $t2		= triple(variable('s'), iri('q'), variable('o2'));
+	my $t1		= triplepattern(variable('s'), iri('p'), variable('o1'));
+	my $t2		= triplepattern(variable('s'), iri('q'), variable('o2'));
 	my $bgp1	= Attean::Algebra::BGP->new(triples => [$t1, $t2]);
 	my $e1		= Attean::ValueExpression->new( value => variable('o1') );
 	my $e2		= Attean::ValueExpression->new( value => variable('o2') );
@@ -557,7 +557,7 @@ subtest 'expected tokens: non-projected extend tokens' => sub {
 	};
 	
 	subtest 'extend within projection' => sub {
-		my $t3		= triple(variable('s'), iri('r'), variable('o3'));
+		my $t3		= triplepattern(variable('s'), iri('r'), variable('o3'));
 		my $bgp2		= Attean::Algebra::BGP->new(triples => [$t3]);
 
 		my $join	= Attean::Algebra::Join->new( children => [$extend, $bgp2] );
@@ -571,7 +571,7 @@ subtest 'expected tokens: non-projected extend tokens' => sub {
 };
 
 subtest 'expected tokens: aggregation' => sub {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my @groups	= Attean::ValueExpression->new( value => variable('s') );
 	my @aggs	= Attean::AggregateExpression->new(
@@ -655,7 +655,7 @@ exit;
 }
 
 {
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my @groups	= Attean::ValueExpression->new( value => variable('s') );
 	my @aggs	= Attean::AggregateExpression->new(
@@ -676,7 +676,7 @@ exit;
 
 {
 	note('Aggregation');
-	my $t		= triple(variable('s'), iri('p'), variable('o'));
+	my $t		= triplepattern(variable('s'), iri('p'), variable('o'));
 	my $bgp		= Attean::Algebra::BGP->new(triples => [$t]);
 	my @groups	= Attean::ValueExpression->new( value => variable('s') );
 	my @aggs	= Attean::AggregateExpression->new(
@@ -699,9 +699,9 @@ exit;
 	note('Ranking');
 	# RANKing example for 2 youngest students per school
 	my $bgp		= Attean::Algebra::BGP->new(triples => [
-		triple(variable('p'), iri('ex:name'), variable('name')),
-		triple(variable('p'), iri('ex:school'), variable('school')),
-		triple(variable('p'), iri('ex:age'), variable('age')),
+		triplepattern(variable('p'), iri('ex:name'), variable('name')),
+		triplepattern(variable('p'), iri('ex:school'), variable('school')),
+		triplepattern(variable('p'), iri('ex:age'), variable('age')),
 	]);
 	my @groups	= Attean::ValueExpression->new( value => variable('school') );
 	my $r_agg	= Attean::AggregateExpression->new(

--- a/t/simple.t
+++ b/t/simple.t
@@ -75,6 +75,16 @@ use Attean;
 }
 
 {
+	note('Attean::Triple with pattern');
+	my $s	= Attean::Variable->new('x');
+	my $p	= Attean::IRI->new('http://example.org/p');
+	my $o	= Attean::Literal->new(value => 'foo', language => 'en-US');
+	my $s2 = Attean::IRI->new('http://example.org/o');
+	dies_ok { my $t1 = Attean::Triple->new($s, $p, $o); } 'croaks on a variable';
+	dies_ok { my $t2 = Attean::Triple->new($s2, $p, $s); } 'croaks on a variable shuffled';
+}
+
+{
 	note('Attean::Result');
 	my $iri	= Attean::IRI->new('http://example.org/p');
 	my $literal	= Attean::Literal->integer(123);


### PR DESCRIPTION
I think this ```BUILD``` method should be able to alert the user not to do that. I've also fixed the instances where the tests did it. There should possibly be a test for quads somewhere too.