### PR TITLE
add perl versions, remove hard-coded dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,18 @@
 language: perl
 
+perl:
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+
 before_install:
   - sudo apt-get update -qq
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+
 install:
-  - "cpanm --quiet --notest Module::Install::AuthorTests"
-  - "cpanm --quiet --notest Module::Install::DOAPChangeSets"
-  - "cpanm --quiet --notest Test::Exception"
-  - "cpanm --quiet --notest Test::LWP::UserAgent"
-  - "cpanm --quiet --notest Test::Modern"
-  - "cpanm --quiet --notest Test::Moose"
-  - "cpanm --quiet --notest Test::Pod"
-  - "cpanm --quiet --notest Test::Pod::Coverage"
-  - "cpanm --quiet --notest Test::Roo"
-  - "cpanm --quiet --notest Regexp::Common"
-  - "cpanm --quiet --notest DBD::Pg"
-  - "cpanm --quiet --notest File::Slurp"
-  - "cpanm --quiet --notest HTTP::Message::PSGI"
-  - "cpanm --quiet --notest XML::Simple"
-  - "cpanm --quiet --notest Algorithm::Combinatorics"
-  - "cpanm --quiet --notest Data::UUID"
-  - "cpanm --quiet --notest DateTime::Format::W3CDTF"
-  - "cpanm --quiet --notest HTTP::Negotiate"
-  - "cpanm --quiet --notest I18N::LangTags"
-  - "cpanm --quiet --notest IRI"
-  - "cpanm --quiet --notest JSON"
-  - "cpanm --quiet --notest List::MoreUtils"
-  - "cpanm --quiet --notest Math::Cartesian::Product"
-  - "cpanm --quiet --notest Module::Pluggable"
-  - "cpanm --quiet --notest Moo"
-  - "cpanm --quiet --notest MooX::Log::Any"
-  - "cpanm --quiet --notest namespace::clean"
-  - "cpanm --quiet --notest Set::Scalar"
-  - "cpanm --quiet --notest Sub::Install"
-  - "cpanm --quiet --notest Sub::Util"
-  - "cpanm --quiet --notest Text::CSV"
-  - "cpanm --quiet --notest Type::Tiny"
-  - "cpanm --quiet --notest URI::Escape"
-  - "cpanm --quiet --notest URI::Namespace"
-  - "cpanm --quiet --notest XML::SAX"
-script:
-  - "perl Makefile.PL && make test"
+  - cpanm --quiet --notest Module::Install::AuthorTests
+  - cpanm --quiet --notest Module::Install::DOAPChangeSets
+  - cpan-install --deps

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,14 +8,12 @@ all_from		'lib/Attean.pm';
 author			'Gregory Todd Williams <gwilliams@cpan.org>';
 license			'perl';
 
+test_requires   'HTTP::Message::PSGI'           => 0;
+test_requires   'Regexp::Common'                => 0;
 test_requires	'Test::Exception'			=> 0;
 test_requires	'Test::LWP::UserAgent'		=> 0;
 test_requires	'Test::More'				=> 0.88;
-
-### This is required for running xt/dawg11.t, which also requires manual
-### downloading of the SPARQL test suite, so will not be relevant to automated
-### tooling:
-# test_requires	'XML::Simple'				=> 0;
+test_requires	'XML::Simple'				=> 0;
 
 perl_version	'5.014';
 


### PR DESCRIPTION
- enabled testing on 5.14 and above versions vs. only current version
- leverage dependency install from Makefile.PL vs. static list in .travis.yml
- updated dependencies to get clean build

results available here:

https://travis-ci.org/cakirke/attean