### PR TITLE
Quick hack to let the cheaper left-hand-side win in HashJoin plans

### DIFF
--- a/lib/Attean/API/QueryPlanner.pm
+++ b/lib/Attean/API/QueryPlanner.pm
@@ -182,7 +182,7 @@ package Attean::API::SimpleCostPlanner 0.017 {
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
 				$cost	= ($lcost + $rcost);
-				$cost += ($lcost > $rcost); # To let the plan with cheaper lhs win
+				$cost += ($lcost < $rcost); # To let the plan with cheaper rhs win
 				$cost	*= 100 unless ($plan->children_are_variable_connected);
 			} elsif ($plan->isa('Attean::Plan::Service')) {
 				my $scost	= 10;
@@ -396,7 +396,7 @@ package Attean::API::IDPJoinPlanner 0.017 {
 					my $mult = $self->_penalize_joins($plan);
 # 					warn "$mult * ($lcost + $rcost)";
 					$cost	= $mult * ($lcost + $rcost);
-					$cost += ($lcost > $rcost); # To let the plan with cheaper lhs win
+					$cost += ($lcost < $rcost); # To let the plan with cheaper rhs win
 				}
 			} elsif ($plan->isa('Attean::Plan::Service')) {
 				my $scost	= 10;

--- a/lib/Attean/API/QueryPlanner.pm
+++ b/lib/Attean/API/QueryPlanner.pm
@@ -182,6 +182,7 @@ package Attean::API::SimpleCostPlanner 0.017 {
 				my $lcost		= $self->cost_for_plan($children[0], $model);
 				my $rcost		= $self->cost_for_plan($children[1], $model);
 				$cost	= ($lcost + $rcost);
+				$cost += ($lcost > $rcost); # To let the plan with cheaper lhs win
 				$cost	*= 100 unless ($plan->children_are_variable_connected);
 			} elsif ($plan->isa('Attean::Plan::Service')) {
 				my $scost	= 10;
@@ -395,6 +396,7 @@ package Attean::API::IDPJoinPlanner 0.017 {
 					my $mult = $self->_penalize_joins($plan);
 # 					warn "$mult * ($lcost + $rcost)";
 					$cost	= $mult * ($lcost + $rcost);
+					$cost += ($lcost > $rcost); # To let the plan with cheaper lhs win
 				}
 			} elsif ($plan->isa('Attean::Plan::Service')) {
 				my $scost	= 10;


### PR DESCRIPTION
So, I wonder if this could actually do the trick we talked about:

If the ```$lcost``` is more than the ```$rcost```, the condition would evaluate to 1, and so the cost is incremented by one, thus penalizing that plan slightly. Should be enough to break the symmetry, right?
It assumes that the LHS is what is materialized though, I haven't checked if that is actually the case in the code. 

Cheers,

Kjetil