### PR TITLE
Issue #44 PR

### DIFF
--- a/lib/Attean/API/Query.pm
+++ b/lib/Attean/API/Query.pm
@@ -162,8 +162,25 @@ package Attean::API::SPARQLSerializable 0.017 {
 	requires 'sparql_tokens';
 	
 	sub as_sparql {
-		my $self	= shift;
-		my $s		= AtteanX::Serializer::SPARQL->new();
+		my $self = shift;
+		my %args = @_;
+
+		my $s = do {
+
+			if ($args{namespaces} && $self->value->isa('Attean::IRI')) {
+
+				my $map = ref $args{namespaces} eq 'URI::NamespaceMap' ?
+						  $args{namespaces} :
+					  ref $args{namespaces} eq 'HASH' ?
+						  URI::NamespaceMap->new($args{namespaces}) :
+						  die ("namespaces value must be URI::NamespaceMap object or HASH refference.");
+
+				AtteanX::Serializer::SPARQL->new(namespaces => $map);
+			} else {
+				AtteanX::Serializer::SPARQL->new();
+			}
+		};
+
 		my $i		= $self->sparql_tokens;
 		my $bytes	= $s->serialize_iter_to_bytes($i);
 		return decode_utf8($bytes);

--- a/t/issue_44.t
+++ b/t/issue_44.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use v5.14;
+use Attean;
+
+my $ns  = {foaf => 'http://xmlns.com/foaf/0.1/'};
+my $map = URI::NamespaceMap->new($ns);
+
+my $value = Attean::ValueExpression->new(value => Attean::IRI->new('http://xmlns.com/foaf/0.1/person'));
+
+is ($value->as_sparql(namespaces => $map), <<IRI, 'as_sparql with URI::NamespaceMap object passed as namespace value');
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+foaf:person
+IRI
+
+is ($value->as_sparql(namespaces => $map), <<IRI, 'as_sparql with HASH ref passed as namespace value');
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+foaf:person
+IRI
+
+is ($value->as_sparql(),<<IRI, 'as_sparql without arguments');
+<http://xmlns.com/foaf/0.1/person>
+IRI
+


### PR DESCRIPTION
Added the namespaces parmeter to as_sparql that accepts either the URI::NamespaceMap object or HASH ref that is then used to create the instance of URI::NamespaceMap inside the method.

Zoran  