### PR TITLE
Moo::Role automatically cleanup namespace

### DIFF
--- a/lib/Attean/API.pm
+++ b/lib/Attean/API.pm
@@ -34,11 +34,11 @@ package Attean::API::BlankOrIRI 0.017 {
 }
 
 package Attean::API::TermOrVariable 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use Sub::Install;
 	use Sub::Util qw(set_subname);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::SPARQLSerializable';
 
@@ -91,8 +91,8 @@ package Attean::Mapper 0.017 {
 package Attean::API::Variable 0.017 {
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
+
 	use Moo::Role;
-	use namespace::clean;
 
 	with 'Attean::API::TermOrVariable';
 
@@ -116,8 +116,9 @@ Returns a string representation of the variable.'
 }
 
 package Attean::API::CanonicalizingBindingSet 0.017 {
-	use Moo::Role;
 	use Attean::RDF;
+
+	use Moo::Role;
 	use namespace::clean;
 
 	with 'MooX::Log::Any';

--- a/lib/Attean/API/Binding.pm
+++ b/lib/Attean/API/Binding.pm
@@ -72,10 +72,10 @@ otherwise.
 use Type::Tiny::Role;
 
 package Attean::API::Binding 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use List::MoreUtils qw(zip);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	requires 'value';
 	requires 'variables';
@@ -179,8 +179,8 @@ package Attean::API::TripleOrQuadPattern 0.017 {
 	use Scalar::Util qw(blessed);
 	use Attean::RDF;
 	use Attean::API::Query;
+
 	use Moo::Role;
-	use namespace::clean;
 
 	with 'Attean::API::SPARQLSerializable';
 	
@@ -280,9 +280,11 @@ parsed from C<< $string >> in SPARQL syntax.
 }
 
 package Attean::API::TripleOrQuad 0.017 {
-	use Moo::Role;
 	use List::MoreUtils qw(any);
 	use Carp;
+
+	use Moo::Role;
+
 	with 'Attean::API::TripleOrQuadPattern';
 
 	sub BUILD {
@@ -297,7 +299,8 @@ package Attean::API::TriplePattern 0.017 {
 	use Moo::Role;
 	use List::MoreUtils qw(zip);
 	use Scalar::Util qw(blessed);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	sub variables { return qw(subject predicate object) }
 
@@ -383,8 +386,8 @@ package Attean::API::Triple 0.017 {
 package Attean::API::QuadPattern 0.017 {
 	use Scalar::Util qw(blessed);
 	use List::MoreUtils qw(zip);
+
 	use Moo::Role;
-	use namespace::clean;
 	
 	sub variables { return qw(subject predicate object graph) }
 	sub value {
@@ -465,10 +468,10 @@ package Attean::API::Quad 0.017 {
 
 
 package Attean::API::Result 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(refaddr);
 	use Types::Standard qw(HashRef);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	has 'eval_stash' => (is => 'rw', isa => HashRef);
 

--- a/lib/Attean/API/Expression.pm
+++ b/lib/Attean/API/Expression.pm
@@ -66,9 +66,9 @@ Returns a string serialization of the expression object.
 =cut
 
 package Attean::API::Expression 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(Str);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::DirectedAcyclicGraph', 'Attean::API::UnionScopeVariables';
 	
@@ -101,10 +101,10 @@ package Attean::API::Expression 0.017 {
 }
 
 package Attean::API::UnaryExpression 0.017 {
-	use Moo::Role;
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::Expression', 'Attean::API::UnaryQueryTree';
 	with 'Attean::API::SPARQLSerializable';
@@ -141,10 +141,10 @@ package Attean::API::UnaryExpression 0.017 {
 }
 
 package Attean::API::BinaryExpression 0.017 {
-	use Moo::Role;
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::Expression', 'Attean::API::BinaryQueryTree';
 	with 'Attean::API::SPARQLSerializable';

--- a/lib/Attean/API/Iterator.pm
+++ b/lib/Attean/API/Iterator.pm
@@ -95,12 +95,12 @@ elements from the referent.
 =cut
 
 package Attean::API::Iterator 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(Str Object InstanceOf);
 	use Role::Tiny;
 	use Carp qw(confess);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	has 'item_type' => (is => 'ro', isa => Str, required => 1);
 	requires 'next';
@@ -380,9 +380,9 @@ package Attean::API::MixedStatementIterator 0.017 {
 }
 
 package Attean::API::ResultIterator 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(Str ArrayRef);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::CanonicalizingBindingIterator';
 	has 'variables' => (is => 'rw', isa => ArrayRef[Str], required => 1);

--- a/lib/Attean/API/Model.pm
+++ b/lib/Attean/API/Model.pm
@@ -116,13 +116,13 @@ subjects and objects present in the specified C<< $graph >>.
 use Attean::API::Binding;
 
 package Attean::API::Model 0.017 {
-	use Moo::Role;
 	use Sub::Install;
 	use Sub::Util qw(set_subname);
 	use URI::Namespace;
 	use Scalar::Util qw(blessed);
 	use List::MoreUtils qw(uniq);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	# get_quads($s, $p, $o, $g)
 	# or:
@@ -237,12 +237,12 @@ package Attean::API::Model 0.017 {
 
 
 package Attean::API::MutableModel 0.017 {
-	use Moo::Role;
 	use Attean::RDF;
 	use LWP::UserAgent;
 	use Encode qw(encode);
 	use Scalar::Util qw(blessed);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	requires 'add_quad';
 	requires 'remove_quad';

--- a/lib/Attean/API/Parser.pm
+++ b/lib/Attean/API/Parser.pm
@@ -53,8 +53,9 @@ parsing.
 use Type::Tiny::Role;
 
 package Attean::API::Parser 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(CodeRef Bool);
+
+	use Moo::Role;
 	use namespace::clean;
 	
 	has 'handler' => (is => 'rw', isa => CodeRef, default => sub { sub {} });
@@ -89,11 +90,11 @@ C<lazy_iris> attribute.
 }
 
 package Attean::API::AbbreviatingParser 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(ConsumerOf InstanceOf Maybe);
 	use URI::NamespaceMap;
 	use Scalar::Util qw(blessed);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::Parser';
 	has 'base' 		=> (is => 'rw', isa => ConsumerOf['Attean::API::IRI'], coerce => sub { blessed($_[0]) ? Attean::IRI->new($_[0]->as_string) : Attean::IRI->new($_[0]) }, predicate => 'has_base');

--- a/lib/Attean/API/Plan.pm
+++ b/lib/Attean/API/Plan.pm
@@ -54,10 +54,10 @@ L<Attean::API::Iterator> object.
 use Type::Tiny::Role;
 
 package Attean::API::Plan 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(ArrayRef CodeRef Str Object InstanceOf Bool Num Int);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	has 'cost' => (is => 'rw', isa => Int, predicate => 'has_cost');
 	has 'distinct' => (is => 'rw', isa => Bool, required => 1, default => 0);
@@ -222,7 +222,6 @@ package Attean::API::BindingSubstitutionPlan 0.017 {
 
 package Attean::API::UnionScopeVariablesPlan 0.017 {
 	use Moo::Role;
-	use namespace::clean;
 
 	with 'Attean::API::Plan';
 	
@@ -242,10 +241,10 @@ package Attean::API::UnionScopeVariablesPlan 0.017 {
 }
 
 package Attean::API::Plan::Join 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(CodeRef);
 	use Types::Standard qw(ArrayRef Str ConsumerOf Bool);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::Plan', 'Attean::API::BinaryQueryTree';
 	with 'Attean::API::UnionScopeVariablesPlan';

--- a/lib/Attean/API/Query.pm
+++ b/lib/Attean/API/Query.pm
@@ -25,10 +25,10 @@ This is a utility package for defining query-related roles:
 =cut
 
 package Attean::API::DirectedAcyclicGraph 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(refaddr);
 	use Types::Standard qw(ArrayRef ConsumerOf);
-	use namespace::clean;
+
+	use Moo::Role;
 
 # =item C<< children >>
 # 
@@ -152,12 +152,12 @@ package Attean::API::DirectedAcyclicGraph 0.017 {
 package Attean::API::SPARQLSerializable 0.017 {
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
-	use Moo::Role;
 	use Encode qw(decode_utf8);
 	use Attean::API::Iterator;
 	use Attean::API::Serializer;
 	use AtteanX::Serializer::SPARQL;
-	use namespace::clean;
+
+	use Moo::Role;
 
 	requires 'sparql_tokens';
 	
@@ -550,9 +550,9 @@ package Attean::API::PropertyPath 0.017 {
 =cut
 
 package Attean::API::UnaryPropertyPath 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(ConsumerOf);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	sub arity { return 1 }
 # 	has 'path' => (is => 'ro', isa => ConsumerOf['Attean::API::PropertyPath'], required => 1);
@@ -580,9 +580,9 @@ package Attean::API::UnaryPropertyPath 0.017 {
 =cut
 
 package Attean::API::NaryPropertyPath 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(ArrayRef ConsumerOf);
-	use namespace::clean;
+
+	use Moo::Role;
 
 # 	has 'children' => (is => 'ro', isa => ArrayRef[ConsumerOf['Attean::API::PropertyPath']], required => 1);
 	requires 'separator';

--- a/lib/Attean/API/QueryPlanner.pm
+++ b/lib/Attean/API/QueryPlanner.pm
@@ -33,17 +33,18 @@ methods that consume the L<Attean::API::CostPlanner> role.
 =cut
 
 package Attean::API::QueryPlanner 0.017 {
-	use Moo::Role;
 	use Types::Standard qw(CodeRef);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	requires 'plan_for_algebra'; # plan_for_algebra($algebra, $model, \@default_graphs)
 }
 
 package Attean::API::CostPlanner 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(refaddr);
 	use Types::Standard qw(CodeRef);
+
+	use Moo::Role;
 	use namespace::clean;
 	with 'Attean::API::QueryPlanner';
 	
@@ -76,14 +77,13 @@ package Attean::API::CostPlanner 0.017 {
 
 package Attean::API::JoinPlanner 0.017 {
 	use Moo::Role;
-	use namespace::clean;
 	requires 'joins_for_plan_alternatives';
 }
 
 package Attean::API::NaiveJoinPlanner 0.017 {
-	use Moo::Role;
 	use Math::Cartesian::Product;
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::JoinPlanner';
 	with 'Attean::API::QueryPlanner';
@@ -109,10 +109,11 @@ package Attean::API::NaiveJoinPlanner 0.017 {
 }
 
 package Attean::API::SimpleCostPlanner 0.017 {
-	use Moo::Role;
-	use namespace::clean;
 	use Types::Standard qw(Int);
 	use Scalar::Util qw(blessed);
+
+	use Moo::Role;
+
 	with 'Attean::API::CostPlanner';
 	with 'MooX::Log::Any';
 
@@ -213,7 +214,6 @@ package Attean::API::SimpleCostPlanner 0.017 {
 }
 
 package Attean::API::IDPJoinPlanner 0.017 {
-	use Moo::Role;
 	use Encode qw(encode);
 	use Attean::RDF;
 	use LWP::UserAgent;
@@ -225,7 +225,8 @@ package Attean::API::IDPJoinPlanner 0.017 {
 	use Algorithm::Combinatorics qw(subsets);
 	use List::Util qw(min);
 	use Math::Cartesian::Product;
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::JoinPlanner';
 	with 'Attean::API::SimpleCostPlanner';

--- a/lib/Attean/API/Serializer.pm
+++ b/lib/Attean/API/Serializer.pm
@@ -107,9 +107,9 @@ package Attean::API::Serializer 0.017 {
 
 package Attean::API::AbbreviatingSerializer 0.017 {
 	# Serializer that can make use of a base IRI and/or prefix IRI mappings
-	use Moo::Role;
 	use Types::Standard qw(InstanceOf ConsumerOf Maybe);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	with 'Attean::API::Serializer';
 

--- a/lib/Attean/API/Store.pm
+++ b/lib/Attean/API/Store.pm
@@ -40,10 +40,10 @@ package Attean::API::Store 0.017 {
 }
 
 package Attean::API::TripleStore 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
-	use namespace::clean;
-	
+
+	use Moo::Role;
+
 	with 'Attean::API::Store';
 
 	requires 'get_triples';
@@ -107,10 +107,10 @@ package Attean::API::TimeCacheableTripleStore 0.017 {
 }
 
 package Attean::API::QuadStore 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
-	use namespace::clean;
-	
+
+	use Moo::Role;
+
 	with 'Attean::API::Store';
 
 	requires 'get_quads';

--- a/lib/Attean/API/Term.pm
+++ b/lib/Attean/API/Term.pm
@@ -106,14 +106,14 @@ Returns true if the term has a true SPARQL "effective boolean value", false othe
 }
 
 package Attean::API::Literal 0.017 {
-	use Moo::Role;
 	use IRI;
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(Maybe Str ConsumerOf);
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
 	use Attean::API::Query;
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::Term';
 	with 'Attean::API::SPARQLSerializable';
@@ -290,9 +290,10 @@ package Attean::API::Literal 0.017 {
 }
 
 package Attean::API::DateTimeLiteral 0.017 {
-	use Moo::Role;
 	use DateTime::Format::W3CDTF;
-	use namespace::clean;
+
+	use Moo::Role;
+
 	sub datetime {
 		my $self	= shift;
 		my $w3c	= DateTime::Format::W3CDTF->new;
@@ -306,10 +307,10 @@ package Attean::API::CanonicalizingLiteral 0.017 {
 }
 
 package Attean::API::NumericLiteral 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed looks_like_number);
-	use namespace::clean;
-	
+
+	use Moo::Role;
+
 	sub compare {
 		my ($a, $b)	= @_;
 		return 1 unless blessed($b);
@@ -497,12 +498,12 @@ package Attean::API::NumericLiteral 0.017 {
 }
 
 package Attean::API::Blank 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
 	use Attean::API::Query;
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	sub ebv { return 1; }
 	with 'Attean::API::Term', 'Attean::API::BlankOrIRI';
@@ -523,13 +524,13 @@ package Attean::API::Blank 0.017 {
 }
 
 package Attean::API::IRI 0.017 {
-	use Moo::Role;
 	use IRI;
 	use Scalar::Util qw(blessed);
 	use AtteanX::SPARQL::Constants;
 	use AtteanX::SPARQL::Token;
 	use Attean::API::Query;
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	sub ebv { return 1; }
 	with 'Attean::API::Term', 'Attean::API::BlankOrIRI';

--- a/lib/Attean/TripleModel.pm
+++ b/lib/Attean/TripleModel.pm
@@ -212,10 +212,10 @@ Attempts to delegate to all the underlying stores if that store consumes Attean:
 }
 
 package Attean::AddativeTripleModelRole 0.017 {
-	use Moo::Role;
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(CodeRef);
-	use namespace::clean;
+
+	use Moo::Role;
 	
 	with 'Attean::API::Model';
 	has 'store_constructor'	=> (is => 'ro', isa => CodeRef, required => 1);

--- a/lib/AtteanX/API/JoinRotatingPlanner.pm
+++ b/lib/AtteanX/API/JoinRotatingPlanner.pm
@@ -37,11 +37,11 @@ plan.
 
 package AtteanX::API::JoinRotatingPlanner 0.017 {
 	# Rotate joins like (A⋈B)⋈C to A⋈(B⋈C), with the ability to coalesce B⋈C (e.g. for adjacent BGPs)
-	use Moo::Role;
 	use Attean;
 	use Attean::RDF;
-	use namespace::clean;
-	
+
+	use Moo::Role;
+
 	requires 'coalesce_rotated_join';
 	requires 'allow_join_rotation';
 	

--- a/lib/AtteanX/API/Lexer.pm
+++ b/lib/AtteanX/API/Lexer.pm
@@ -43,9 +43,9 @@ of characters, constant strings, and fixed-length buffers.
 
 package AtteanX::API::Lexer 0.017 {
 	use strict;
-	use Moo::Role;
 	use Types::Standard qw(FileHandle Ref Str Int ArrayRef HashRef ConsumerOf InstanceOf);
-	use namespace::clean;
+
+	use Moo::Role;
 
 	has file			=> ( is => 'ro', isa => FileHandle, required => 1, );
 	has linebuffer		=> ( is => 'rw', isa => Str, default => '', );


### PR DESCRIPTION
There is no need to manually “use namespace::clean”, we just need to
make “use Moo::Role” the last import.