### PR TITLE
Compatibility methods with Trine

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,7 @@ requires		'Math::Cartesian::Product'	=> 1.008;
 requires		'Module::Pluggable'			=> 0;
 requires		'Moo'						=> 2.000002;
 requires		'MooX::Log::Any'			=> 0;
+requires		'MooX::Aliases'			=> 0;
 requires		'namespace::clean'			=> 0;
 requires		'Role::Tiny'				=> 2.000003;
 requires		'Set::Scalar'				=> 0;

--- a/lib/Attean/Blank.pm
+++ b/lib/Attean/Blank.pm
@@ -38,8 +38,9 @@ package Attean::Blank 0.017 {
 	use Types::Standard qw(Str);
 	use Data::UUID;
 	use namespace::clean;
-	
-	has 'value' => (is => 'ro', isa => Str, required => 1);
+	use MooX::Aliases;
+
+	has 'value' => (is => 'ro', isa => Str, required => 1, alias => 'blank_identifier');
 	has 'ntriples_string'	=> (is => 'ro', isa => Str, lazy => 1, builder => '_ntriples_string');
 	
 	with 'Attean::API::Blank';

--- a/lib/Attean/IRI.pm
+++ b/lib/Attean/IRI.pm
@@ -80,7 +80,7 @@ Returns true if C<< $iri >> is equal to the invocant, false otherwise.
 
 =item C<< as_string >>
 
-Returns the IRI value.
+Returns the IRI value. C<< uri >> is an alias for the same method.
 
 =cut
 
@@ -88,6 +88,12 @@ Returns the IRI value.
 		my $self	= shift;
 		return $self->abs;
 	}
+
+	sub uri {
+		my $self	= shift;
+		return $self->abs;
+	}
+
 }
 
 1;

--- a/lib/Attean/Literal.pm
+++ b/lib/Attean/Literal.pm
@@ -57,9 +57,10 @@ package Attean::Literal 0.017 {
 	use Sub::Util qw(set_subname);
 	use Scalar::Util qw(blessed);
 	use namespace::clean;
+	use MooX::Aliases;
 	
 	my $XSD_STRING	= IRI->new(value => 'http://www.w3.org/2001/XMLSchema#string');
-	has 'value'				=> (is => 'ro', isa => Str, required => 1);
+	has 'value'				=> (is => 'ro', isa => Str, required => 1, alias => 'literal_value');
 	has 'language'			=> (is => 'ro', isa => Maybe[Str], predicate => 'has_language');
 	has 'datatype'			=> (
 		is => 'ro',
@@ -73,6 +74,7 @@ package Attean::Literal 0.017 {
 				return blessed($dt) ? Attean::IRI->new($dt->as_string) : Attean::IRI->new($dt)
 			}
 		},
+		handles => { 'literal_datatype' => 'as_string' },
 		default => sub { $XSD_STRING }
 	);
 	has 'ntriples_string'	=> (is => 'ro', isa => Str, lazy => 1, builder => '_ntriples_string');

--- a/lib/Attean/Literal.pm
+++ b/lib/Attean/Literal.pm
@@ -61,7 +61,7 @@ package Attean::Literal 0.017 {
 	
 	my $XSD_STRING	= IRI->new(value => 'http://www.w3.org/2001/XMLSchema#string');
 	has 'value'				=> (is => 'ro', isa => Str, required => 1, alias => 'literal_value');
-	has 'language'			=> (is => 'ro', isa => Maybe[Str], predicate => 'has_language');
+	has 'language'			=> (is => 'ro', isa => Maybe[Str], predicate => 'has_language', alias => 'literal_value_language');
 	has 'datatype'			=> (
 		is => 'ro',
 		isa => InstanceOf['Attean::IRI'],

--- a/lib/Attean/Literal.pm
+++ b/lib/Attean/Literal.pm
@@ -66,6 +66,7 @@ package Attean::Literal 0.017 {
 		is => 'ro',
 		isa => InstanceOf['Attean::IRI'],
 		required => 1,
+		predicate => 'has_datatype', # Meaningless with RDF 1.1
 		coerce => sub {
 			my $dt	= shift;
 			if (blessed($dt) and $dt->isa('Attean::IRI')) {


### PR DESCRIPTION
I have been working on putting Attean support in RDF::RDFa::Generator, which relies on certain Trine::Node methods. Here's a patch for the methods I found I needed. 

I don't know if it is actually a good idea, it is OK to not bring along too much legacy from Trine too. Perhaps the best would be to have a compatibility module, but that would be a lot more work, I would guess.

What do you think?