### PR TITLE
Canonize shebangs

### DIFF
--- a/bin/attean_parse
+++ b/bin/attean_parse
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use v5.14;
 use autodie;

--- a/bin/attean_query
+++ b/bin/attean_query
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use v5.14;
 use warnings;

--- a/bin/canonicalize_bgp.pl
+++ b/bin/canonicalize_bgp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use v5.14;
 use warnings;


### PR DESCRIPTION
Using "/usr/bin/env" in shebangs is not welcomed by software distributors (https://fedoraproject.org/wiki/Packaging:Guidelines?rd=Packaging/Guidelines#Shebang_lines, https://www.debian.org/doc/packaging-manuals/python-policy/ch-python.html#s-interpreter_loc).

This pull request fixes by utilizing ExtUtils::MakeMaker feature that rewrites the paths to perl used at build time.

I know that different people have different opinions on this issue but if you merged this patch, it would saved some people from maintaining a special patch.