### PR TITLE
URI for langString is incorrect

### DIFF
--- a/lib/Attean/Literal.pm
+++ b/lib/Attean/Literal.pm
@@ -94,7 +94,7 @@ package Attean::Literal 0.018 {
 		my $orig	= shift;
 		my $self	= shift;
 		if ($self->has_language) {
-			return Attean::IRI->new(value => 'http://www.w3.org/2001/XMLSchema#langString');
+			return Attean::IRI->new(value => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
 		} else {
 			return $self->$orig(@_);
 		}

--- a/lib/Attean/Plan.pm
+++ b/lib/Attean/Plan.pm
@@ -987,7 +987,7 @@ package Attean::Plan::Extend 0.018 {
 				}
 				foreach my $s (@strings) {
 					die unless ($s->does('Attean::API::Literal'));
-					die if ($s->datatype and not($s->datatype->value =~ m<http://www.w3.org/2001/XMLSchema#(langString|string)>));
+					die if ($s->datatype and not($s->datatype->value =~ m<http://www.w3.org/(1999/02/22-rdf-syntax-ns#langString|2001/XMLSchema#string)>));
 					if (my $l2 = $s->language) {
 						if (my $l1 = $args{language}) {
 							if ($l1 ne $l2) {
@@ -1030,20 +1030,20 @@ package Attean::Plan::Extend 0.018 {
 			} elsif ($func eq 'STRLANG') {
 				my ($term, $lang)	= @terms;
 				die unless ($term->does('Attean::API::Literal'));
-				die unless ($term->datatype->value =~ m<http://www.w3.org/2001/XMLSchema#(langString|string)>);
+				die unless ($term->datatype->value =~ m<http://www.w3.org/(1999/02/22-rdf-syntax-ns#langString|2001/XMLSchema#string)>);
 				die if ($term->language);
 				return Attean::Literal->new(value => $term->value, language => $lang->value);
 			} elsif ($func eq 'STRDT') {
 				my ($term, $dt)	= @terms;
 				die unless ($term->does('Attean::API::Literal'));
-				die unless ($term->datatype->value =~ m<http://www.w3.org/2001/XMLSchema#(langString|string)>);
+				die unless ($term->datatype->value =~ m<http://www.w3.org/(1999/02/22-rdf-syntax-ns#langString|2001/XMLSchema#string)>);
 				die if ($term->language);
 # 				my ($term, $dt)	= map { $self->evaluate_expression($model, $_, $r) } @{ $expr->children };
 				return Attean::Literal->new(value => $term->value, datatype => $dt->value);
 			} elsif ($func eq 'REPLACE') {
 				my ($term, $pat, $rep)	= @terms;
 				die unless ($term->does('Attean::API::Literal'));
-				die unless ($term->language or $term->datatype->value =~ m<http://www.w3.org/2001/XMLSchema#(langString|string)>);
+				die unless ($term->language or $term->datatype->value =~ m<http://www.w3.org/(1999/02/22-rdf-syntax-ns#langString|2001/XMLSchema#string)>);
 # 				my ($term, $pat, $rep)	= map { $self->evaluate_expression($model, $_, $r) } @{ $expr->children };
 				my $value	= $term->value;
 				my $pattern	= $pat->value;

--- a/t/simple.t
+++ b/t/simple.t
@@ -33,7 +33,7 @@ use Attean;
 	is($a->value, 'foo', 'value');
 	is($a->language, 'en-US', 'language');
 	does_ok($a->datatype, 'Attean::API::IRI', 'datatype IRI');
-	is($a->datatype->as_string, 'http://www.w3.org/2001/XMLSchema#langString', 'language literal datatype is xsd:langString');
+	is($a->datatype->as_string, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', 'language literal datatype is rdf:langString');
 	is($a->ntriples_string, '"foo"@en-US', 'ntriples_string');
 }
 


### PR DESCRIPTION
Hi! 

I just found a bug, and I just wanted to post an heads-up about it. In Attean, the URI of langString is given as ```xsd:langString```, but according to [the spec](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string), it is ```rdf:langString```. 

I'll try to fix it, but I just wanted to post this in case I don't get around to it for some reason.