### PR TITLE
Removing mentionds of perlrdf.org

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -17,6 +17,4 @@
 ## Getting Help
 
 * [IRC in the #perlrdf channel on irc.perl.org](irc://irc.perl.org/perlrdf)
-* [Mailing list](http://lists.perlrdf.org/listinfo/dev)
-* [Website](http://www.perlrdf.org)
 * [@kasei](http://twitter.com/kasei/) or [@perlrdf](http://twitter.com/perlrdf/) on Twitter

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ questions.
 
 You can also:
 
-* Email our [mailing list](http://lists.perlrdf.org/listinfo/dev)
 * Create a new [GitHub Issue](https://github.com/kasei/attean/issues) or submit a pull request
 
 Licensing

--- a/lib/Attean.pm
+++ b/lib/Attean.pm
@@ -392,7 +392,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API.pm
+++ b/lib/Attean/API.pm
@@ -242,7 +242,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/AbbreviatingParser.pod
+++ b/lib/Attean/API/AbbreviatingParser.pod
@@ -41,7 +41,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/AbbreviatingSerializer.pod
+++ b/lib/Attean/API/AbbreviatingSerializer.pod
@@ -48,7 +48,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/AggregateExpression.pod
+++ b/lib/Attean/API/AggregateExpression.pod
@@ -44,7 +44,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/AppendableSerializer.pod
+++ b/lib/Attean/API/AppendableSerializer.pod
@@ -31,7 +31,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/AtOnceParser.pod
+++ b/lib/Attean/API/AtOnceParser.pod
@@ -70,7 +70,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Binding.pm
+++ b/lib/Attean/API/Binding.pm
@@ -568,7 +568,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Blank.pod
+++ b/lib/Attean/API/Blank.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/BlankOrIRI.pod
+++ b/lib/Attean/API/BlankOrIRI.pod
@@ -23,7 +23,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/BulkUpdatableModel.pod
+++ b/lib/Attean/API/BulkUpdatableModel.pod
@@ -50,7 +50,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Expression.pm
+++ b/lib/Attean/API/Expression.pm
@@ -242,7 +242,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/IRI.pod
+++ b/lib/Attean/API/IRI.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Iterator.pm
+++ b/lib/Attean/API/Iterator.pm
@@ -429,7 +429,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 L<Attean::API::RepeatableIterator>
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Literal.pod
+++ b/lib/Attean/API/Literal.pod
@@ -59,7 +59,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/MixedStatementParser.pod
+++ b/lib/Attean/API/MixedStatementParser.pod
@@ -35,7 +35,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/MixedStatementSerializer.pod
+++ b/lib/Attean/API/MixedStatementSerializer.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Model.pm
+++ b/lib/Attean/API/Model.pm
@@ -379,7 +379,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/MutableModel.pod
+++ b/lib/Attean/API/MutableModel.pod
@@ -83,7 +83,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/MutableTripleStore.pod
+++ b/lib/Attean/API/MutableTripleStore.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Parser.pm
+++ b/lib/Attean/API/Parser.pm
@@ -341,7 +341,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Plan.pm
+++ b/lib/Attean/API/Plan.pm
@@ -270,7 +270,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/PullParser.pod
+++ b/lib/Attean/API/PullParser.pod
@@ -69,7 +69,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/PushParser.pod
+++ b/lib/Attean/API/PushParser.pod
@@ -70,7 +70,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Quad.pod
+++ b/lib/Attean/API/Quad.pod
@@ -58,7 +58,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/QuadParser.pod
+++ b/lib/Attean/API/QuadParser.pod
@@ -34,7 +34,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/QuadPattern.pod
+++ b/lib/Attean/API/QuadPattern.pod
@@ -53,7 +53,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/QuadSerializer.pod
+++ b/lib/Attean/API/QuadSerializer.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Query.pm
+++ b/lib/Attean/API/Query.pm
@@ -648,7 +648,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/QueryPlanner.pm
+++ b/lib/Attean/API/QueryPlanner.pm
@@ -554,7 +554,7 @@ influenced by L<The ICS-FORTH Heuristics-based SPARQL Planner
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/RepeatableIterator.pod
+++ b/lib/Attean/API/RepeatableIterator.pod
@@ -58,7 +58,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Result.pod
+++ b/lib/Attean/API/Result.pod
@@ -42,7 +42,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/ResultParser.pod
+++ b/lib/Attean/API/ResultParser.pod
@@ -34,7 +34,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/ResultSerializer.pod
+++ b/lib/Attean/API/ResultSerializer.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Serializer.pm
+++ b/lib/Attean/API/Serializer.pm
@@ -204,7 +204,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Store.pm
+++ b/lib/Attean/API/Store.pm
@@ -219,7 +219,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Term.pm
+++ b/lib/Attean/API/Term.pm
@@ -585,7 +585,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TermOrVariable.pod
+++ b/lib/Attean/API/TermOrVariable.pod
@@ -33,7 +33,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TermParser.pod
+++ b/lib/Attean/API/TermParser.pod
@@ -34,7 +34,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TermSerializer.pod
+++ b/lib/Attean/API/TermSerializer.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Triple.pod
+++ b/lib/Attean/API/Triple.pod
@@ -63,7 +63,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TripleOrQuad.pod
+++ b/lib/Attean/API/TripleOrQuad.pod
@@ -22,7 +22,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TripleParser.pod
+++ b/lib/Attean/API/TripleParser.pod
@@ -34,7 +34,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TriplePattern.pod
+++ b/lib/Attean/API/TriplePattern.pod
@@ -58,7 +58,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/TripleSerializer.pod
+++ b/lib/Attean/API/TripleSerializer.pod
@@ -43,7 +43,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/API/Variable.pod
+++ b/lib/Attean/API/Variable.pod
@@ -37,7 +37,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/AggregateExpression.pod
+++ b/lib/Attean/AggregateExpression.pod
@@ -49,7 +49,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Algebra.pm
+++ b/lib/Attean/Algebra.pm
@@ -1630,7 +1630,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/BindingEqualityTest.pm
+++ b/lib/Attean/BindingEqualityTest.pm
@@ -249,7 +249,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Blank.pm
+++ b/lib/Attean/Blank.pm
@@ -75,7 +75,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/CodeIterator.pm
+++ b/lib/Attean/CodeIterator.pm
@@ -103,7 +103,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Expression.pm
+++ b/lib/Attean/Expression.pm
@@ -459,7 +459,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/IDPQueryPlanner.pm
+++ b/lib/Attean/IDPQueryPlanner.pm
@@ -57,7 +57,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/IRI.pm
+++ b/lib/Attean/IRI.pm
@@ -107,7 +107,7 @@ L<IRI>
 
 L<http://www.ietf.org/rfc/rfc3987.txt>
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/IteratorSequence.pm
+++ b/lib/Attean/IteratorSequence.pm
@@ -105,7 +105,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/ListIterator.pm
+++ b/lib/Attean/ListIterator.pm
@@ -125,7 +125,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Literal.pm
+++ b/lib/Attean/Literal.pm
@@ -169,7 +169,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Plan.pm
+++ b/lib/Attean/Plan.pm
@@ -2455,7 +2455,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Quad.pm
+++ b/lib/Attean/Quad.pm
@@ -88,7 +88,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/QuadModel.pm
+++ b/lib/Attean/QuadModel.pm
@@ -150,7 +150,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/QueryPlanner.pm
+++ b/lib/Attean/QueryPlanner.pm
@@ -1011,7 +1011,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/RDF.pm
+++ b/lib/Attean/RDF.pm
@@ -163,7 +163,7 @@ L<IRI>
 
 L<http://www.ietf.org/rfc/rfc3987.txt>
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Result.pm
+++ b/lib/Attean/Result.pm
@@ -97,7 +97,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/SimpleQueryEvaluator.pm
+++ b/lib/Attean/SimpleQueryEvaluator.pm
@@ -1020,7 +1020,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/TermMap.pm
+++ b/lib/Attean/TermMap.pm
@@ -195,7 +195,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/TreeRewriter.pm
+++ b/lib/Attean/TreeRewriter.pm
@@ -195,7 +195,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Triple.pm
+++ b/lib/Attean/Triple.pm
@@ -92,7 +92,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/TripleModel.pm
+++ b/lib/Attean/TripleModel.pm
@@ -392,7 +392,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/Attean/Variable.pm
+++ b/lib/Attean/Variable.pm
@@ -74,7 +74,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/AtteanX/API/JoinRotatingPlanner.pm
+++ b/lib/AtteanX/API/JoinRotatingPlanner.pm
@@ -108,7 +108,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/AtteanX/API/Lexer.pm
+++ b/lib/AtteanX/API/Lexer.pm
@@ -203,7 +203,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/AtteanX/Parser/SPARQL.pm
+++ b/lib/AtteanX/Parser/SPARQL.pm
@@ -3691,7 +3691,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/AtteanX/Parser/SPARQLXML/SAXHandler.pm
+++ b/lib/AtteanX/Parser/SPARQLXML/SAXHandler.pm
@@ -13,8 +13,7 @@ This document describes AtteanX::Parser::SPARQLXML::SAXHandler version 0.018
 
 This module's API and functionality should be considered unstable.
 In the future, this module may change in backwards-incompatible ways,
-or be removed entirely. If you need functionality that this module provides,
-please L<get in touch|http://www.perlrdf.org/>.
+or be removed entirely.
 
 =head1 SYNOPSIS
 

--- a/lib/AtteanX/Parser/Turtle/Token.pm
+++ b/lib/AtteanX/Parser/Turtle/Token.pm
@@ -147,7 +147,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 

--- a/lib/AtteanX/SPARQL/Token.pm
+++ b/lib/AtteanX/SPARQL/Token.pm
@@ -204,7 +204,7 @@ at L<https://github.com/kasei/attean/issues>.
 
 =head1 SEE ALSO
 
-L<http://www.perlrdf.org/>
+
 
 =head1 AUTHOR
 


### PR DESCRIPTION
So, I suppose we're not getting perlrdf.org back very easily, so I suppose we shouldn't mention it in the docs. Here's are patches to remove it. We can always put it back in if we get it back somehow.

Kjetil