### PR TITLE
Export using Exporter::Tiny instead of Exporter.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ requires		'Algorithm::Combinatorics'	=> 0;
 requires		'Data::UUID'				=> 0;
 requires		'DateTime::Format::W3CDTF'	=> 0;
 requires		'HTTP::Negotiate'			=> 0;
+requires		'Exporter::Tiny'				=> 1.000000;
 requires		'IRI'						=> 0.005;
 requires		'JSON'						=> 0;
 requires		'LWP::UserAgent'			=> 0;

--- a/lib/Attean/RDF.pm
+++ b/lib/Attean/RDF.pm
@@ -37,10 +37,10 @@ package Attean::RDF 0.019 {
 
 	use Attean;
 	use List::MoreUtils qw(zip);
-	require Exporter;
+	require Exporter::Tiny;
 	use namespace::clean;
 
-	our @ISA	= qw(Exporter);
+	our @ISA	= qw(Exporter::Tiny);
 	our @EXPORT	= qw(iri blank literal dtliteral langliteral variable triple quad triplepattern quadpattern);
 
 =item C<< variable( $value ) >>


### PR DESCRIPTION
Attean already has an indirect dependency on Exporter::Tiny because it uses Type::Tiny.

Exporter::Tiny allows things like:

```
use Attean::RDF dtliteral => { -as => "datatyped_literal" };
```