### PR TITLE
Add holds method to stores

### DIFF
--- a/lib/Attean/API/Store.pm
+++ b/lib/Attean/API/Store.pm
@@ -74,6 +74,12 @@ package Attean::API::TripleStore 0.019 {
 		my $self	= shift;
 		return $self->count_triples();
 	}
+
+	sub holds {
+	  my $self = shift;
+	  return ($self->count_triples_estimate(@_) > 0)
+	}
+
 }
 
 package Attean::API::MutableTripleStore 0.019 {
@@ -136,7 +142,12 @@ package Attean::API::QuadStore 0.019 {
 		my $self	= shift;
 		return $self->count_quads(@_);
 	}
-	
+
+	sub holds {
+	  my $self = shift;
+	  return ($self->count_quads_estimate(@_) > 0)
+	}
+
 	sub get_graphs {
 		my $self	= shift;
 		my $iter	= $self->get_quads(@_);

--- a/t/model-quad.t
+++ b/t/model-quad.t
@@ -49,6 +49,8 @@ use Type::Tiny::Role;
 	is($model->count_quads($s2), 3);
 	is($model->count_quads(), 4);
 	is($model->count_quads(undef, $p), 2);
+	ok($model->holds($s2));
+	ok(!$model->holds($s2, $g));
 
 	{
 		note('get_quads single-term matching with undef placeholders');


### PR DESCRIPTION
Inspired by the `holds` method of https://github.com/linkeddata/rdflib.js I figured we should have something similar in Attean, so I attempted this default implementation, which would work under the assumption that the count estimate would be at least positive if there is one match. Perhaps that assumption is something we should spec.

However, the test fails for me, and I don't understand why. Figured I'd let you have a look anyway.

