### PR TITLE
Attribute to omit base to have all relative URIs

### DIFF
--- a/lib/Attean/API/AbbreviatingSerializer.pod
+++ b/lib/Attean/API/AbbreviatingSerializer.pod
@@ -40,6 +40,13 @@ in the serialized data should be resolved.
 A L<URI::NamespaceMap> object representing prefix and namespace URI
 pairs that can be used to create abbreviations.
 
+=item C<< omit_base >>
+
+A boolean attribute that can be set to true if the serializer should
+not include the base URI in the serialized output. This is useful for
+making relative URIs that can be resolved by other systems.
+
+
 =back
 
 =head1 BUGS

--- a/lib/Attean/API/Serializer.pm
+++ b/lib/Attean/API/Serializer.pm
@@ -107,7 +107,7 @@ package Attean::API::Serializer 0.022 {
 
 package Attean::API::AbbreviatingSerializer 0.022 {
 	# Serializer that can make use of a base IRI and/or prefix IRI mappings
-	use Types::Standard qw(InstanceOf ConsumerOf Maybe);
+	use Types::Standard qw(InstanceOf ConsumerOf Maybe Bool);
 
 	use Moo::Role;
 
@@ -115,6 +115,7 @@ package Attean::API::AbbreviatingSerializer 0.022 {
 
 	has base		=> (is => 'ro', isa => ConsumerOf['Attean::API::IRI'], predicate => 'has_base');
 	has namespaces	=> (is => 'ro', isa => Maybe[InstanceOf['URI::NamespaceMap']], predicate => 'has_namespaces');
+	has omit_base => (is => 'ro', isa => Bool, default => 0);
 }
 
 package Attean::API::AppendableSerializer 0.022 {


### PR DESCRIPTION
When rereading the [Design Issue on relative URIs](https://www.w3.org/DesignIssues/Relative), I realized that we have the same problem as Jena, even for the abbrieviating serializer, as it will end up putting a `@base` in the file. 

Then, I figured, it should be easy to solve at the API level, just not print the `@base` if URIs have been made relative to them. So, even thought we haven't got any serializers that do this now, having a boolean attribute for it makes sense, so that's what this patch adds.