### PR TITLE
Add keywords that take recent perls to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: perl
 
 perl:
+  - "stable"
+  - "dev"
   - "5.22"
   - "5.20"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ perl:
   - "stable"
   - "dev"
   - "5.22"
-  - "5.20"
   - "5.18"
-  - "5.16"
   - "5.14"
 
 before_install:


### PR DESCRIPTION
Here's something that works with my Travis setup: Adding `dev` and `stable` runs the test suite on the most recent development release and also the most recent `stable` release respectively. It is a bit to see that it actually works, because it starts out not finding it, but the tests should be running on them if you look further down. 

Also, I omitted two older perls. Feel free to cherry pick if you still want them.