### PR TITLE
First useful type and coercions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ license			'perl';
 test_requires	'HTTP::Message::PSGI'		=> 0;
 test_requires	'Regexp::Common'			=> 0;
 test_requires	'Test::Exception'			=> 0;
+test_requires	'Test::Requires'			=> 0;
 test_requires	'Test::LWP::UserAgent'		=> 0;
 test_requires	'Test::More'				=> 0.88;
 test_requires	'XML::Simple'				=> 0;

--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -11,18 +11,18 @@ our $VERSION = '0.024';
 
 =head1 NAME
 
-Types::Attean - type constraints for dealing with Attean classes
+Types::Attean - Type constraints for dealing with Attean classes
 
 =head1 SYNOPSIS
 
 TODO
-  package Namespace::Counter {
+  package IRI::Counter {
     use Moo;  # or Moose
-    use Types::Namespace qw( Namespace );
+    use Types::Attean qw( AtteanIRI );
 
-    has ns => (
+    has iri => (
       is => "ro",
-      isa => Namespace,
+      isa => AtteanIRI,
       required => 1,
     );
 
@@ -43,24 +43,11 @@ forth. It builds on L<Types::URI>.
 
 A class type for L<Attean::IRI>.
 
-Can coerce from L<URI>, L<IRI>, L<URI::Namespace>, L<Path::Tiny>, and strings.
+Can coerce from L<URI>, L<IRI>, L<URI::Namespace> and strings.
 
-=item C<< NamespaceMap >>
+=head1 OTHER COERCIONS
 
-A class type for L<URI::NamespaceMap>.
-
-Can coerce from a hashref of C<< prefix => URI >> pairs.
-
-=item C<< Uri >>, C<< Iri >>
-
-These namespaces are re-exported from L<Types::URI>, but with an
-additional coercion from the C<< Namespace >> type.
-
-=back
-
-=head1 FURTHER DETAILS
-
-See L<URI::NamespaceMap> for further details about authors, license, etc.
+This library can also coerce from C<Attean::IRI> to the C<Namespace> type defined in L<URI::Namespace>.
 
 =cut
 
@@ -73,14 +60,8 @@ __PACKAGE__->add_type(
 
 
 AtteanIRI->coercion->add_type_coercions(
-#         Uuid        ,=> q{ do { require Attean::IRI; "Attean::IRI"->new("urn:uuid:$_") } },
          Str         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_) } },
-#         Path        ,=> q{ do { require Attean::IRI; my $u = "URI::file"->new($_); "Attean::IRI"->new($u->as_string) } },
-#         ScalarRef   ,=> q{ do { require Attean::IRI; my $u = "URI"->new("data:"); $u->data($$_); "Attean::IRI"->new($u->as_string) } },
-#         HashRef     ,=> q{ do { require Attean::IRI; "Attean::IRI"->new(URI::FromHash::uri(%$_)) } },
-#         $TrineNode  ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri_value) } },
-#         $TrineNS    ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri->uri_value) } },
-#         $XmlNS      ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri) } },
+#         HashRef     ,=> q{ do { require Attean::IRI; "Attean::IRI"->new(URI::FromHash::uri(%$_)) } }, # TODO: Perhaps use for a shortcut to populate rather than parse?
          Namespace   ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
          Uri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
          Iri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },

--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -74,7 +74,7 @@ __PACKAGE__->add_type(
 
 AtteanIRI->coercion->add_type_coercions(
 #         Uuid        ,=> q{ do { require Attean::IRI; "Attean::IRI"->new("urn:uuid:$_") } },
-#         Str         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_) } },
+         Str         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_) } },
 #         Path        ,=> q{ do { require Attean::IRI; my $u = "URI::file"->new($_); "Attean::IRI"->new($u->as_string) } },
 #         ScalarRef   ,=> q{ do { require Attean::IRI; my $u = "URI"->new("data:"); $u->data($$_); "Attean::IRI"->new($u->as_string) } },
 #         HashRef     ,=> q{ do { require Attean::IRI; "Attean::IRI"->new(URI::FromHash::uri(%$_)) } },

--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -1,0 +1,93 @@
+package Types::Attean;
+use strict;
+use warnings;
+
+use Type::Library -base, -declare => qw( AtteanIri );
+use Types::Standard qw( Str InstanceOf );
+use Types::URI qw();
+
+our $VERSION = '1.08';
+
+=head1 NAME
+
+Types::Attean - type constraints for dealing with Attean classes
+
+=head1 SYNOPSIS
+
+TODO
+  package Namespace::Counter {
+    use Moo;  # or Moose
+    use Types::Namespace qw( Namespace );
+
+    has ns => (
+      is => "ro",
+      isa => Namespace,
+      required => 1,
+    );
+
+    sub count_uses_in_document { ... }
+  }
+
+=head1 DESCRIPTION
+
+Types::Attean is a type constraint library suitable for use with
+L<Moo>/L<Moose> attributes, L<Kavorka> sub signatures, and so
+forth. It builds on L<Types::URI>.
+
+=head1 TYPES
+
+=over
+
+=item C<< AtteanIri >>
+
+A class type for L<Attean::IRI>.
+
+Can coerce from L<URI>, L<IRI>, L<URI::Namespace>, L<Path::Tiny>, and strings.
+
+=item C<< NamespaceMap >>
+
+A class type for L<URI::NamespaceMap>.
+
+Can coerce from a hashref of C<< prefix => URI >> pairs.
+
+=item C<< Uri >>, C<< Iri >>
+
+These namespaces are re-exported from L<Types::URI>, but with an
+additional coercion from the C<< Namespace >> type.
+
+=back
+
+=head1 FURTHER DETAILS
+
+See L<URI::NamespaceMap> for further details about authors, license, etc.
+
+=cut
+
+__PACKAGE__->add_type(
+	name       => AtteanIri,
+	parent     => InstanceOf['Attean::IRI']
+);
+
+
+
+
+# AtteanIri->coercion->add_type_coercions(
+#         Uuid        ,=> q{ do { require IRI; "IRI"->new("urn:uuid:$_") } },
+#         Str         ,=> q{ do { require IRI; "IRI"->new($_) } },
+#         Path        ,=> q{ do { require IRI; my $u = "URI::file"->new($_); "IRI"->new($u->as_string) } },
+#         ScalarRef   ,=> q{ do { require IRI; my $u = "URI"->new("data:"); $u->data($$_); "IRI"->new($u->as_string) } },
+#         HashRef     ,=> q{ do { require IRI; "IRI"->new(URI::FromHash::uri(%$_)) } },
+#         $TrineNode  ,=> q{ do { require IRI; "IRI"->new($_->uri_value) } },
+#         $TrineNS    ,=> q{ do { require IRI; "IRI"->new($_->uri->uri_value) } },
+#         $XmlNS      ,=> q{ do { require IRI; "IRI"->new($_->uri) } },
+#         Uri         ,=> q{ do { require IRI; "IRI"->new($_->as_string) } },
+# );
+
+Namespace->coercion->add_type_coercions(
+  AtteanIRI ,=> q{ do { require URI::Namespace; "Attean::IRI"->new($_->as_string) } },
+);
+
+require Attean::IRI;
+
+
+1;

--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -2,11 +2,12 @@ package Types::Attean;
 use strict;
 use warnings;
 
-use Type::Library -base, -declare => qw( AtteanIri );
+use Type::Library -base, -declare => qw( AtteanIRI );
 use Types::Standard qw( Str InstanceOf );
-use Types::URI qw();
+use Types::URI qw( Uri Iri );
+use Types::Namespace qw( Namespace );
 
-our $VERSION = '1.08';
+our $VERSION = '0.024';
 
 =head1 NAME
 
@@ -64,27 +65,29 @@ See L<URI::NamespaceMap> for further details about authors, license, etc.
 =cut
 
 __PACKAGE__->add_type(
-	name       => AtteanIri,
+	name       => AtteanIRI,
 	parent     => InstanceOf['Attean::IRI']
 );
 
 
 
 
-# AtteanIri->coercion->add_type_coercions(
-#         Uuid        ,=> q{ do { require IRI; "IRI"->new("urn:uuid:$_") } },
-#         Str         ,=> q{ do { require IRI; "IRI"->new($_) } },
-#         Path        ,=> q{ do { require IRI; my $u = "URI::file"->new($_); "IRI"->new($u->as_string) } },
-#         ScalarRef   ,=> q{ do { require IRI; my $u = "URI"->new("data:"); $u->data($$_); "IRI"->new($u->as_string) } },
-#         HashRef     ,=> q{ do { require IRI; "IRI"->new(URI::FromHash::uri(%$_)) } },
-#         $TrineNode  ,=> q{ do { require IRI; "IRI"->new($_->uri_value) } },
-#         $TrineNS    ,=> q{ do { require IRI; "IRI"->new($_->uri->uri_value) } },
-#         $XmlNS      ,=> q{ do { require IRI; "IRI"->new($_->uri) } },
-#         Uri         ,=> q{ do { require IRI; "IRI"->new($_->as_string) } },
-# );
+AtteanIRI->coercion->add_type_coercions(
+#         Uuid        ,=> q{ do { require Attean::IRI; "Attean::IRI"->new("urn:uuid:$_") } },
+#         Str         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_) } },
+#         Path        ,=> q{ do { require Attean::IRI; my $u = "URI::file"->new($_); "Attean::IRI"->new($u->as_string) } },
+#         ScalarRef   ,=> q{ do { require Attean::IRI; my $u = "URI"->new("data:"); $u->data($$_); "Attean::IRI"->new($u->as_string) } },
+#         HashRef     ,=> q{ do { require Attean::IRI; "Attean::IRI"->new(URI::FromHash::uri(%$_)) } },
+#         $TrineNode  ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri_value) } },
+#         $TrineNS    ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri->uri_value) } },
+#         $XmlNS      ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri) } },
+         Namespace   ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
+         Uri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
+         Iri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
+);
 
 Namespace->coercion->add_type_coercions(
-  AtteanIRI ,=> q{ do { require URI::Namespace; "Attean::IRI"->new($_->as_string) } },
+  AtteanIRI ,=> q{ do { require URI::Namespace; "URI::Namespace"->new($_->as_string) } },
 );
 
 require Attean::IRI;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -26,28 +26,18 @@ my $atteaniri = Attean::IRI->new('http://www.example.net/');
   is($nsuri->as_string, 'http://www.example.net/', "Correct string URI to Namespace");
 }
 
-{
-  my $uri = URI->new('http://www.example.net/');
+_test_to_attean(URI->new('http://www.example.net/'));
+
+_test_to_attean(IRI->new('http://www.example.net/'));
+
+_test_to_attean(URI::Namespace->new('http://www.example.net/'));
+
+sub _test_to_attean {
+  my $uri = shift;
   my $airi = to_AtteanIRI($uri);
   isa_ok($airi, 'Attean::IRI');
-  is("$uri", 'http://www.example.net/', "Correct string URI from Uri");
+  is($airi->as_string, 'http://www.example.net/', 'Correct string URI from ' . ref($uri));
   ok($airi->equals($atteaniri), 'Is the same URI');
 }
-
-{
-  my $iri = IRI->new('http://www.example.net/');
-  my $airi = to_AtteanIRI($iri);
-  isa_ok($airi, 'Attean::IRI');
-  is($airi->as_string, 'http://www.example.net/', "Correct string IRI from Iri");
-  ok($airi->equals($atteaniri), 'Is the same IRI');
-}
-
-{
-  my $nsuri = URI::Namespace->new('http://www.example.net/');
-  my $airi = to_AtteanIRI($nsuri);
-  isa_ok($airi, 'Attean::IRI');
-  is($airi->as_string, 'http://www.example.net/', "Correct string URI from Namespace");
-  ok($airi->equals($atteaniri), 'Is the same URI');
-}
-
+  
 done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -38,6 +38,12 @@ sub _test_to_attean {
   isa_ok($airi, 'Attean::IRI');
   is($airi->as_string, 'http://www.example.net/', 'Correct string URI from ' . ref($uri));
   ok($airi->equals($atteaniri), 'Is the same URI');
+
+  # TODO: Something like this should work too?
+  # my $aciri = Attean::IRI->new($uri); 
+  # isa_ok($aciri, 'Attean::IRI');
+  # is($aciri->as_string, 'http://www.example.net/', 'Correct string URI from ' . ref($uri));
+  # ok($aciri->equals($atteaniri), 'Is the same URI');
 }
   
 done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -4,26 +4,24 @@ use strict;
 use warnings;
 use Test::More;
 use Attean;
-#use Test::Requires { 'Attean::IRI' => '0.023' };
+use Test::Requires { 'Attean::IRI' => '0.023' };
 use Types::URI qw( to_Uri to_Iri );
 use Types::Namespace qw( to_Namespace );
 #use Types::Attean qw(to_AtteanIri);
 use Attean::IRI;
 
-subtest 'Coercions to other URIs' => sub {
-  my $atteaniri = Attean::IRI->new('http://www.example.net/');
+my $atteaniri = Attean::IRI->new('http://www.example.net/');
+
+my $uri = to_Uri($atteaniri);
+isa_ok($uri, 'URI');
+is("$uri", 'http://www.example.net/', "Correct string URI");
+
+my $iri = to_Iri($atteaniri);
+isa_ok($iri, 'IRI');
+is($iri->as_string, 'http://www.example.net/', "Correct string URI");
   
-  my $uri = to_Uri($atteaniri);
-  isa_ok($uri, 'URI');
-  is("$uri", 'http://www.example.net/', "Correct string URI");
- 
-  my $iri = to_Iri($atteaniri);
-  isa_ok($iri, 'IRI');
-  is($iri->as_string, 'http://www.example.net/', "Correct string URI");
-  
-  my $nsuri = to_Namespace($atteaniri);
-  isa_ok($nsuri, 'Namespace');
-  is($nsuri->as_string, 'http://www.example.net/', "Correct string URI");
-};
+my $nsuri = to_Namespace($atteaniri);
+isa_ok($nsuri, 'URI::Namespace');
+is($nsuri->as_string, 'http://www.example.net/', "Correct string URI");
 
 done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Attean;
+#use Test::Requires { 'Attean::IRI' => '0.023' };
+use Types::URI qw( to_Uri to_Iri );
+use Types::Namespace qw( to_Namespace );
+#use Types::Attean qw(to_AtteanIri);
+use Attean::IRI;
+
+subtest 'Coercions to other URIs' => sub {
+  my $atteaniri = Attean::IRI->new('http://www.example.net/');
+  
+  my $uri = to_Uri($atteaniri);
+  isa_ok($uri, 'URI');
+  is("$uri", 'http://www.example.net/', "Correct string URI");
+ 
+  my $iri = to_Iri($atteaniri);
+  isa_ok($iri, 'IRI');
+  is($iri->as_string, 'http://www.example.net/', "Correct string URI");
+  
+  my $nsuri = to_Namespace($atteaniri);
+  isa_ok($nsuri, 'Namespace');
+  is($nsuri->as_string, 'http://www.example.net/', "Correct string URI");
+};
+
+done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -7,21 +7,47 @@ use Attean;
 use Test::Requires { 'Attean::IRI' => '0.023' };
 use Types::URI qw( to_Uri to_Iri );
 use Types::Namespace qw( to_Namespace );
-#use Types::Attean qw(to_AtteanIri);
+use Types::Attean qw(to_AtteanIRI);
 use Attean::IRI;
 
 my $atteaniri = Attean::IRI->new('http://www.example.net/');
 
-my $uri = to_Uri($atteaniri);
-isa_ok($uri, 'URI');
-is("$uri", 'http://www.example.net/', "Correct string URI");
-
-my $iri = to_Iri($atteaniri);
-isa_ok($iri, 'IRI');
-is($iri->as_string, 'http://www.example.net/', "Correct string URI");
+{
+  my $uri = to_Uri($atteaniri);
+  isa_ok($uri, 'URI');
+  is("$uri", 'http://www.example.net/', "Correct string URI to Uri");
   
-my $nsuri = to_Namespace($atteaniri);
-isa_ok($nsuri, 'URI::Namespace');
-is($nsuri->as_string, 'http://www.example.net/', "Correct string URI");
+  my $iri = to_Iri($atteaniri);
+  isa_ok($iri, 'IRI');
+  is($iri->as_string, 'http://www.example.net/', "Correct string URI to Iri");
+  
+  my $nsuri = to_Namespace($atteaniri);
+  isa_ok($nsuri, 'URI::Namespace');
+  is($nsuri->as_string, 'http://www.example.net/', "Correct string URI to Namespace");
+}
+
+{
+  my $uri = URI->new('http://www.example.net/');
+  my $airi = to_AtteanIRI($uri);
+  isa_ok($airi, 'Attean::IRI');
+  is("$uri", 'http://www.example.net/', "Correct string URI from Uri");
+  ok($airi->equals($atteaniri), 'Is the same URI');
+}
+
+{
+  my $iri = IRI->new('http://www.example.net/');
+  my $airi = to_AtteanIRI($iri);
+  isa_ok($airi, 'Attean::IRI');
+  is($airi->as_string, 'http://www.example.net/', "Correct string IRI from Iri");
+  ok($airi->equals($atteaniri), 'Is the same IRI');
+}
+
+{
+  my $nsuri = URI::Namespace->new('http://www.example.net/');
+  my $airi = to_AtteanIRI($nsuri);
+  isa_ok($airi, 'Attean::IRI');
+  is($airi->as_string, 'http://www.example.net/', "Correct string URI from Namespace");
+  ok($airi->equals($atteaniri), 'Is the same URI');
+}
 
 done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -32,6 +32,8 @@ _test_to_attean(IRI->new('http://www.example.net/'));
 
 _test_to_attean(URI::Namespace->new('http://www.example.net/'));
 
+_test_to_attean('http://www.example.net/');
+
 sub _test_to_attean {
   my $uri = shift;
   my $airi = to_AtteanIRI($uri);


### PR DESCRIPTION
This is in partial fulfillment of #138 , but it should be useful already, so I'm submitting a PR with it.

The next step is to have it coerce upon construction. That doesn't work yet (there are commented out tests about it). 

I'm not quite sure how we'd do it, since we only require attributes in the API, I'm not sure where we set the `coerce` flag. It creates a `to_AtteanIRI` method that could be called also. We could also not coerce by default in the constructor, but instead do it in the helper methods, in this case in `Attean::RDF::iri`. So, there is a bunch of options. But I think this can be merged before that.