### PR TITLE
fix Moo::Role/Role::Tiny imports

### DIFF
--- a/lib/Attean.pm
+++ b/lib/Attean.pm
@@ -68,6 +68,7 @@ package Attean {
 	use HTTP::Negotiate qw(choose);
 	use List::MoreUtils qw(any all);
 	use Module::Load::Conditional qw(can_load);
+	use Role::Tiny ();
 	use Sub::Util qw(set_subname);
 	use namespace::clean;
 	

--- a/lib/Attean/API/Binding.pm
+++ b/lib/Attean/API/Binding.pm
@@ -296,7 +296,6 @@ package Attean::API::TripleOrQuad 0.024 {
 }
 
 package Attean::API::TriplePattern 0.024 {
-	use Moo::Role;
 	use List::MoreUtils qw(zip);
 	use Scalar::Util qw(blessed);
 

--- a/lib/Attean/API/Iterator.pm
+++ b/lib/Attean/API/Iterator.pm
@@ -97,7 +97,6 @@ elements from the referent.
 package Attean::API::Iterator 0.024 {
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(Str Object InstanceOf);
-	use Role::Tiny;
 	use Carp qw(confess);
 
 	use Moo::Role;
@@ -112,30 +111,30 @@ package Attean::API::Iterator 0.024 {
 		my $args	= shift;
 		$self->$orig($args);
 		my $role	= $self->item_type;
-		if (Role::Tiny->is_role($role)) {
+		if (Moo::Role->is_role($role)) {
 			my $check	= sub {
 				my $check = shift;
-				return ($role eq $check or Role::Tiny::does_role($role, $check));
+				return ($role eq $check or Moo::Role::does_role($role, $check));
 			};
 			if ($check->('Attean::API::Quad')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::QuadIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::QuadIterator');
 			} elsif ($check->('Attean::API::Triple')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::TripleIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::TripleIterator');
 			} elsif ($check->('Attean::API::TripleOrQuad')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::MixedStatementIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::MixedStatementIterator');
 			} elsif ($check->('Attean::API::Result')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::ResultIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::ResultIterator');
 				my $vars	= $args->{variables} // confess "Construction of a Attean::API::ResultIterator must include a variables list";
 				$self->variables($vars);
 			} elsif ($check->('Attean::API::Term')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::TermIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::TermIterator');
 			} elsif ($check->('Attean::API::ResultOrTerm')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::ResultOrTermIterator');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::ResultOrTermIterator');
 				$self->variables($args->{variables} || []);
 			}
 
 			if ($self->does('Attean::API::RepeatableIterator') and $check->('Attean::API::Binding')) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::CanonicalizingBindingSet');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::CanonicalizingBindingSet');
 			}
 		}
 	};

--- a/lib/Attean/API/Model.pm
+++ b/lib/Attean/API/Model.pm
@@ -313,6 +313,7 @@ package Attean::API::MutableModel 0.024 {
 	use LWP::UserAgent;
 	use Encode qw(encode);
 	use Scalar::Util qw(blessed);
+	use Role::Tiny ();
 
 	use Moo::Role;
 	

--- a/lib/Attean/API/Store.pm
+++ b/lib/Attean/API/Store.pm
@@ -166,6 +166,7 @@ package Attean::API::QuadStore 0.024 {
 }
 
 package Attean::API::MutableQuadStore 0.024 {
+	use Role::Tiny ();
 	use Moo::Role;
 	use Type::Tiny::Role;
 	with 'Attean::API::QuadStore';

--- a/lib/Attean/API/Term.pm
+++ b/lib/Attean/API/Term.pm
@@ -151,9 +151,9 @@ package Attean::API::Literal 0.024 {
 		if (my $dt = $self->datatype) {
 			my $type	= $dt->value;
 			if ($type =~ qr<^http://www[.]w3[.]org/2001/XMLSchema#(?:integer|decimal|float|double|non(?:Positive|Negative)Integer|(?:positive|negative)Integer|long|int|short|byte|unsigned(?:Long|Int|Short|Byte))$>) {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::NumericLiteral');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::NumericLiteral');
 			} elsif ($type eq 'http://www.w3.org/2001/XMLSchema#dateTime') {
-				Role::Tiny->apply_roles_to_object($self, 'Attean::API::DateTimeLiteral');
+				Moo::Role->apply_roles_to_object($self, 'Attean::API::DateTimeLiteral');
 			}
 		}
 	};

--- a/lib/Attean/CodeIterator.pm
+++ b/lib/Attean/CodeIterator.pm
@@ -57,6 +57,7 @@ package Attean::CodeIterator 0.024 {
 	use Type::Tiny::Role;
 	use Scalar::Util qw(blessed);
 	use Types::Standard qw(CodeRef ArrayRef);
+	use Role::Tiny ();
 	use namespace::clean;
 	
 	with 'Attean::API::Iterator';


### PR DESCRIPTION
Moo::Role and Role::Tiny shouldn't be 'use'd in the same package.

Moo::Roles shouldn't be applied using Role::Tiny.

Role::Tiny should be loaded explicitly in the locations using its
subs/methods directly.

This fixes #141.