### PR TITLE
More coercions, take 2

### DIFF
--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -50,7 +50,11 @@ forth. It builds on L<Types::URI>.
 
 A class type for L<Attean::IRI>.
 
-Can coerce from L<URI>, L<IRI>, L<URI::Namespace> and strings.
+Can coerce from L<URI>, L<IRI>, L<URI::Namespace>,
+L<RDF::Trine::Node::Resource>, L<RDF::Trine::Namespace>,
+L<XML::Namespace> and strings.
+
+Additionally, a C<ScalarRef> can be coerced into a C<data> URI.
 
 =back
 

--- a/lib/Types/Attean.pm
+++ b/lib/Types/Attean.pm
@@ -3,9 +3,16 @@ use strict;
 use warnings;
 
 use Type::Library -base, -declare => qw( AtteanIRI );
-use Types::Standard qw( Str InstanceOf );
+use Types::Standard qw( Str InstanceOf ScalarRef );
 use Types::URI qw( Uri Iri );
 use Types::Namespace qw( Namespace );
+use Types::Path::Tiny  qw( Path );
+use Types::UUID        qw( Uuid );
+
+my $TrineNode = InstanceOf['RDF::Trine::Node::Resource'];
+my $TrineNS   = InstanceOf['RDF::Trine::Namespace'];
+my $XmlNS     = InstanceOf['XML::Namespace'];
+
 
 our $VERSION = '0.025';
 
@@ -67,11 +74,14 @@ AtteanIRI->coercion->add_type_coercions(
          Namespace   ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
          Uri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
          Iri         ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->as_string) } },
+         Uuid        ,=> q{ do { require Attean::IRI; "Attean::IRI"->new("urn:uuid:$_") } },
+         Path        ,=> q{ do { require Attean::IRI; my $u = "URI::file"->new($_); "Attean::IRI"->new($u->as_string) } },
+         ScalarRef   ,=> q{ do { require Attean::IRI; my $u = "URI"->new("data:"); $u->data($$_); "Attean::IRI"->new($u->as_string) } },
+         $TrineNode  ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri_value) } },
+         $TrineNS    ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri->uri_value) } },
+         $XmlNS      ,=> q{ do { require Attean::IRI; "Attean::IRI"->new($_->uri) } },
 );
 
-Namespace->coercion->add_type_coercions(
-  AtteanIRI ,=> q{ do { require URI::Namespace; "URI::Namespace"->new($_->as_string) } },
-);
 
 require Attean::IRI;
 

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -5,8 +5,7 @@ use warnings;
 use Test::More;
 use Attean;
 use Test::Requires { 'Attean::IRI' => '0.023' };
-use Types::URI qw( to_Uri to_Iri );
-use Types::Namespace qw( to_Namespace );
+use Types::Namespace qw( to_Uri to_Iri to_Namespace );
 use Types::Attean qw(to_AtteanIRI);
 use Attean::IRI;
 use Module::Load::Conditional qw(can_load);
@@ -56,5 +55,5 @@ sub _test_to_attean {
   # is($aciri->as_string, 'http://www.example.net/', 'Correct string URI from ' . ref($uri));
   # ok($aciri->equals($atteaniri), 'Is the same URI');
 }
-  
+
 done_testing;

--- a/t/types-iri.t
+++ b/t/types-iri.t
@@ -9,6 +9,7 @@ use Types::URI qw( to_Uri to_Iri );
 use Types::Namespace qw( to_Namespace );
 use Types::Attean qw(to_AtteanIRI);
 use Attean::IRI;
+use Module::Load::Conditional qw(can_load);
 
 my $atteaniri = Attean::IRI->new('http://www.example.net/');
 
@@ -33,6 +34,14 @@ _test_to_attean(IRI->new('http://www.example.net/'));
 _test_to_attean(URI::Namespace->new('http://www.example.net/'));
 
 _test_to_attean('http://www.example.net/');
+
+SKIP: {
+  skip 'RDF::Trine is not installed', 3 unless can_load( modules => { 'RDF::Trine' => 0 });
+  _test_to_attean(RDF::Trine::iri('http://www.example.net/'));
+}
+
+
+
 
 sub _test_to_attean {
   my $uri = shift;


### PR DESCRIPTION
#144 got a bit messy, I think it makes sense to merge this cherry-pick instead. 

What I was worried about in #144 was that the depenendency chain became too long, mainly through the dependency on URI::NamespaceMap, which brings in many things that could be optional, like UUID types. 

I didn't at first realize that URI::NamespaceMap had that effect, so I thought I should remove some coercions from Attean to avoid it, and then, it didn't anyway.

So, either we can do this, or I can make more stuff optional in URI::NamespaceMap. Unless you are really worried about the dependency chain, I suggest we merge this PR. 

URI::NamespaceMap has quite a lot of moving parts already, since the mapping libraries are optional, and further optionals make testing harder.

I think it should be possible to make some coercions optional later if we find it is needed.
